### PR TITLE
Add GitHub Actions CI/CD workflows and branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,83 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+      
+      - name: Run clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+      
+      - name: Run tests
+        run: cargo test --workspace
+      
+      - name: Check documentation
+        run: cargo doc --workspace --no-deps --document-private-items
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: check
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      
+      - name: Build release
+        run: cargo build --release --workspace
+      
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: event-modeler-linux-x86_64
+          path: target/release/event_modeler
+          retention-days: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,13 +77,13 @@ jobs:
       
       - name: Package
         run: |
-          cd target/${{ matrix.target }}/release
+          pushd target/${{ matrix.target }}/release
           if [ "${{ matrix.os }}" = "windows-latest" ]; then
             7z a ../../../${{ matrix.name }}.zip ${{ matrix.binary }}
           else
             tar czf ../../../${{ matrix.name }}.tar.gz ${{ matrix.binary }}
           fi
-          cd -
+          popd
         shell: bash
       
       - name: Upload Release Asset (tar.gz)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,105 @@
+name: Release
+
+on:
+  release:
+    types: [created]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-release:
+    name: Build Release
+    strategy:
+      matrix:
+        include:
+          # Linux
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            binary: event_modeler
+            name: event-modeler-linux-x86_64
+          
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            binary: event_modeler
+            name: event-modeler-linux-x86_64-musl
+            use-cross: true
+          
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            binary: event_modeler
+            name: event-modeler-linux-aarch64
+            use-cross: true
+          
+          # macOS
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            binary: event_modeler
+            name: event-modeler-macos-x86_64
+          
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            binary: event_modeler
+            name: event-modeler-macos-aarch64
+          
+          # Windows
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            binary: event_modeler.exe
+            name: event-modeler-windows-x86_64
+    
+    runs-on: ${{ matrix.os }}
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      
+      - name: Install cross
+        if: matrix.use-cross == true
+        run: cargo install cross --git https://github.com/cross-rs/cross
+      
+      - name: Build
+        run: |
+          if [ "${{ matrix.use-cross }}" = "true" ]; then
+            cross build --release --target ${{ matrix.target }}
+          else
+            cargo build --release --target ${{ matrix.target }}
+          fi
+        shell: bash
+      
+      - name: Package
+        run: |
+          cd target/${{ matrix.target }}/release
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+            7z a ../../../${{ matrix.name }}.zip ${{ matrix.binary }}
+          else
+            tar czf ../../../${{ matrix.name }}.tar.gz ${{ matrix.binary }}
+          fi
+          cd -
+        shell: bash
+      
+      - name: Upload Release Asset (tar.gz)
+        if: matrix.os != 'windows-latest'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ matrix.name }}.tar.gz
+          asset_name: ${{ matrix.name }}.tar.gz
+          asset_content_type: application/gzip
+      
+      - name: Upload Release Asset (zip)
+        if: matrix.os == 'windows-latest'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ matrix.name }}.zip
+          asset_name: ${{ matrix.name }}.zip
+          asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
             binary: event_modeler
             name: event-modeler-linux-x86_64
+            use-cross: false
           
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
@@ -36,17 +37,20 @@ jobs:
             target: x86_64-apple-darwin
             binary: event_modeler
             name: event-modeler-macos-x86_64
+            use-cross: false
           
           - os: macos-latest
             target: aarch64-apple-darwin
             binary: event_modeler
             name: event-modeler-macos-aarch64
+            use-cross: false
           
           # Windows
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             binary: event_modeler.exe
             name: event-modeler-windows-x86_64
+            use-cross: false
     
     runs-on: ${{ matrix.os }}
     

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Event Modeler
 
+[![CI](https://github.com/jwilger/event_modeler/workflows/CI/badge.svg)](https://github.com/jwilger/event_modeler/actions/workflows/ci.yml)
+
 Generate Event Modeling diagrams from text descriptions. Write `.eventmodel` files, get SVG/PDF diagrams.
 
 ## Quick Start


### PR DESCRIPTION
- Add CI workflow that runs all pre-commit checks (fmt, clippy, test, doc)
- Add release workflow that builds binaries for all major platforms
- Configure branch protection requiring PR approval and passing CI checks
- Add CI status badge to README

The CI workflow runs on all pushes to main and PR events, ensuring code quality checks pass before merging. The release workflow triggers on GitHub release creation and builds binaries for:
- Linux (x86_64, x86_64-musl, aarch64)
- macOS (x86_64, aarch64)
- Windows (x86_64)

Branch protection ensures all changes go through PR review with passing CI.

🤖 Generated with [Claude Code](https://claude.ai/code)