### PR TITLE
Fix code block text color contrast in light mode

### DIFF
--- a/.github/templates/landing-page.html
+++ b/.github/templates/landing-page.html
@@ -329,6 +329,7 @@
         
         .code-block {
             background: var(--code-bg-light);
+            color: var(--text-light);
             padding: 1.5rem;
             border-radius: 0.5rem;
             overflow-x: auto;
@@ -349,6 +350,7 @@
         
         code {
             background: var(--code-bg-light);
+            color: var(--text-light);
             padding: 0.2em 0.4em;
             border-radius: 3px;
             font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Code', monospace;

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "event_modeler"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 authors = ["John Wilger"]
 description = "A type-safe Event Modeling diagram generator"


### PR DESCRIPTION
## Summary
- Fix illegible code blocks on the landing page in light mode
- Add explicit text color to code blocks and inline code elements
- Bump version to 0.1.3 for release

## Changes
- Added `color: var(--text-light);` to `.code-block` and `code` CSS classes
- This ensures proper readability in light mode while maintaining dark mode styles
- The code blocks now properly use var(--text-light) in light mode and var(--text-dark) in dark mode

## Test plan
- [x] Verified CSS changes maintain theme-aware styling
- [ ] Visual inspection of landing page in both light and dark modes after deployment

🤖 Generated with [Claude Code](https://claude.ai/code)