### PR TITLE
Fix version display and correct .eventmodel syntax example

### DIFF
--- a/.github/templates/landing-page.html
+++ b/.github/templates/landing-page.html
@@ -504,24 +504,26 @@
         <div class="code-example">
             <h2 class="section-title" id="quick-start">See It In Action</h2>
             <p style="text-align: center; margin-bottom: 2rem;">Write simple text, get beautiful diagrams:</p>
-            <div class="code-block"><pre>// Define your commands
-command CreateOrder {
-  OrderDetails details
-  CustomerInfo customer
-}
+            <div class="code-block"><pre>Title: Order Processing System
 
-// Define your events  
-event OrderCreated {
-  OrderId id
-  OrderDetails details
-  Timestamp createdAt
-}
+Swimlane: Customer Interface
+- Command: CreateOrder
+- Projection: OrderSummary
 
-// Define your projections
-projection OrderSummary {
-  from OrderCreated
-  shows OrderStatus
-}</pre></div>
+Swimlane: Order Processing
+- Event: OrderCreated
+- Event: OrderShipped
+- Aggregate: Order
+
+Swimlane: Fulfillment
+- Policy: ShipOrder
+- External System: ShippingProvider
+
+# Define relationships
+CreateOrder -> OrderCreated
+OrderCreated -> Order
+OrderCreated -> ShipOrder
+ShipOrder -> OrderShipped</pre></div>
             <p style="text-align: center; margin-top: 2rem;">Run <code>event_modeler diagram model.eventmodel</code> and get a professional diagram instantly!</p>
         </div>
     </section>
@@ -550,7 +552,7 @@ projection OrderSummary {
     <footer>
         <div class="container">
             <p>Made with ❤️ for the Event Modeling community</p>
-            <p style="margin-top: 0.5rem; font-size: 0.9rem;">Event Modeler v__VERSION__</p>
+            <p style="margin-top: 0.5rem; font-size: 0.9rem;">Event Modeler __VERSION__</p>
         </div>
     </footer>
 </body>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "event_modeler"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 authors = ["John Wilger"]
 description = "A type-safe Event Modeling diagram generator"


### PR DESCRIPTION
## Summary
- Fix duplicate 'v' prefix in version display at bottom of landing page
- Update .eventmodel syntax example to match actual parser implementation
- Bump version to 0.1.4 for release

## Changes
1. **Version Display Fix**: Removed the hardcoded 'v' prefix from footer since __VERSION__ is replaced with the full tag name (e.g., "v0.1.3")
2. **Syntax Example Update**: Replaced incorrect syntax example with the actual syntax our parser expects:
   - Removed invalid curly brace syntax and field definitions
   - Added proper Title header
   - Added Swimlane sections with dash-prefixed entity lists
   - Added arrow connector syntax for relationships
   - Now matches test fixtures and parser implementation

## Test plan
- [x] Verified syntax example matches test fixtures in tests/parsing/fixtures/
- [x] Confirmed version display will render correctly
- [ ] Visual inspection of landing page after deployment

🤖 Generated with [Claude Code](https://claude.ai/code)