### PR TITLE
Phase 6 Step 1: Canvas and Workflow Title

### DIFF
--- a/PLANNING.md
+++ b/PLANNING.md
@@ -308,12 +308,13 @@ For Phase 6 only, due to the incremental visual development approach:
    - Compare with `tests/fixtures/acceptance/example.png`
    - Refine implementation to match style as closely as possible
    - Do NOT commit generated SVG/PNG files
-4. Once satisfied with visual output, commit code changes and push
-5. Create a PR (NOT draft) for just that element
-6. Monitor for Copilot review and address feedback
-7. **Wait for PR to be merged** - merge indicates approval to proceed
-8. Once merged, immediately proceed to next step
-9. The merged PR serves as user approval of the visual output
+4. **IMPORTANT**: Do NOT commit and push until you are satisfied with your comparison between the generated diagram and example.png
+5. Once satisfied with visual output, THEN commit code changes and push
+6. Create a PR (NOT draft) for just that element
+7. Monitor for Copilot review and address feedback
+8. **Wait for PR to be merged** - merge indicates approval to proceed
+9. Once merged, immediately proceed to next step
+10. The merged PR serves as user approval of the visual output
 
 This ensures each visual element matches expectations before building on it.
 
@@ -344,8 +345,8 @@ This ensures each visual element matches expectations before building on it.
 - Do NOT wait for explicit approval comments
 
 **Current Progress**:
-- ✅ Step 0: Delete and Initialize (COMPLETE - PR #28 created, awaiting approval)
-- ⏸️ Step 1: Canvas and Workflow Title (not started - awaiting Step 0 approval)
+- ✅ Step 0: Delete and Initialize (COMPLETE - PR #28 merged)
+- 🔄 Step 1: Canvas and Workflow Title (IN PROGRESS)
 - ⏸️ Step 2: Swimlanes (not started)
 - ⏸️ Step 3: Slice Headers (not started)
 
@@ -703,9 +704,14 @@ Following our type-driven testing ADR:
 **For Phase 6 Incremental Steps**:
 12. Review PLANNING.md, update with current status, and await approval before proceeding to next step
 
+**EXCEPTION for Phase 6 Visual Development**: 
+- The normal "commit after every small task" rule is SUSPENDED for Phase 6
+- Instead, only commit AFTER you are satisfied with the visual comparison to example.png
+- This ensures commits only contain visually correct implementations
+
 This ensures:
-1. **Extremely frequent verification** that code compiles and tests pass
-2. **Incremental commits** capturing each small working change
+1. **Visual correctness** before committing any changes
+2. **Clean commits** that represent visually verified implementations
 3. **Early detection** of any breaking changes
 4. **Clean commit history** with each commit representing buildable code
 5. **Early PR creation** for visibility and CI feedback

--- a/src/diagram/svg.rs
+++ b/src/diagram/svg.rs
@@ -5,27 +5,41 @@
 use super::{EventModelDiagram, Result};
 
 // Constants for SVG dimensions and text coordinates
-const VIEW_BOX_WIDTH: u32 = 800;
-const VIEW_BOX_HEIGHT: u32 = 600;
-const TEXT_X: u32 = 20;
-const TEXT_Y: u32 = 40;
+const DEFAULT_WIDTH: u32 = 1200;
+const DEFAULT_HEIGHT: u32 = 800;
+const MARGIN: u32 = 10;
+const TITLE_FONT_SIZE: u32 = 14;
+const TITLE_Y: u32 = 25;
+
+// Colors
+const BACKGROUND_COLOR: &str = "#f8f8f8"; // Light gray background
+const TEXT_COLOR: &str = "#333333"; // Dark gray text
 
 /// Renders an event model diagram to SVG format.
 ///
 /// This function takes a constructed diagram and produces the SVG representation.
 pub fn render_to_svg(diagram: &EventModelDiagram) -> Result<String> {
-    // For now, just render a minimal SVG with the workflow title
+    // Step 1: Canvas with workflow title
     let svg = format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {} {}">
-  <text x="{}" y="{}" font-family="Arial, sans-serif" font-size="24" font-weight="bold">
+  <!-- Canvas background -->
+  <rect x="0" y="0" width="{}" height="{}" fill="{}" stroke="none"/>
+  
+  <!-- Workflow title -->
+  <text x="{}" y="{}" font-family="Arial, sans-serif" font-size="{}" font-weight="normal" fill="{}">
     {}
   </text>
 </svg>"#,
-        VIEW_BOX_WIDTH,
-        VIEW_BOX_HEIGHT,
-        TEXT_X,
-        TEXT_Y,
+        DEFAULT_WIDTH,
+        DEFAULT_HEIGHT,
+        DEFAULT_WIDTH,
+        DEFAULT_HEIGHT,
+        BACKGROUND_COLOR,
+        MARGIN,
+        TITLE_Y,
+        TITLE_FONT_SIZE,
+        TEXT_COLOR,
         diagram.workflow_title().as_str()
     );
 


### PR DESCRIPTION
## Summary
- Implements Step 1 of Phase 6 incremental diagram module rewrite
- Adds canvas rendering with workflow title
- Styles match the gold standard example.png

## Changes
- Updated SVG constants for proper dimensions and styling
- Light gray background (#f8f8f8) to match example
- Adjusted font size (14px) and weight (normal) to match example
- Dark gray text color (#333333) for better readability
- Title positioned at top left with appropriate margins

## Visual Output
The diagram now renders a canvas with the workflow title "User Account Signup" at the top left, matching the style of example.png.

## Test Plan
- [x] cargo build succeeds
- [x] cargo test --workspace passes
- [x] cargo clippy shows no warnings
- [x] cargo fmt has been run
- [x] Visual comparison with example.png confirms matching style

🤖 Generated with Claude Code