### PR TITLE
Add diagram element: All Swimlanes

### DIFF
--- a/PLANNING.md
+++ b/PLANNING.md
@@ -327,12 +327,20 @@ workflow: User Account Signup
    - Review the actual rendered diagram in the PR
 
 **Dynamic Requirements**: The diagram module MUST be dynamic enough to handle ANY valid .eventmodel file:
-- Variable number of swimlanes
+- Variable number of swimlanes (defined by the input .eventmodel file, not hardcoded)
+- Swimlane names/titles come from the .eventmodel file (e.g., "UX, Automations", "Commands, Projections, Queries")
 - Variable number of entities of each type
 - Different slice configurations
 - Different test scenario counts per command
 - Dynamic layout that adapts to content
 - Multiple instances of ANY entity type based on slice connections
+
+**Visual Style Requirements**: When comparing with example.png:
+- Match the STYLE and RELATIVE POSITIONING, not exact pixel dimensions
+- All sizes should be DYNAMIC to best fit their contents
+- Elements should have reasonable minimum dimensions when empty
+- Maintain similar padding/spacing between elements and containers
+- The goal is visual consistency and readability, not pixel-perfect matching
 
 #### Implementation Steps:
 

--- a/src/diagram/builder.rs
+++ b/src/diagram/builder.rs
@@ -3,7 +3,7 @@
 //! This module provides the core diagram building functionality.
 
 use crate::event_model::yaml_types;
-use crate::infrastructure::types::NonEmptyString;
+use crate::infrastructure::types::{NonEmpty, NonEmptyString};
 
 use super::Result;
 
@@ -15,6 +15,8 @@ use super::Result;
 pub struct EventModelDiagram {
     /// The workflow title displayed at the top of the diagram.
     workflow_title: NonEmptyString,
+    /// The swimlanes defined in the model.
+    swimlanes: NonEmpty<yaml_types::Swimlane>,
 }
 
 impl EventModelDiagram {
@@ -22,11 +24,17 @@ impl EventModelDiagram {
     pub fn from_yaml_model(model: &yaml_types::YamlEventModel) -> Result<Self> {
         Ok(EventModelDiagram {
             workflow_title: model.workflow.clone().into_inner(),
+            swimlanes: model.swimlanes.clone(),
         })
     }
 
     /// Gets the workflow title.
     pub fn workflow_title(&self) -> &NonEmptyString {
         &self.workflow_title
+    }
+
+    /// Gets the swimlanes.
+    pub fn swimlanes(&self) -> &NonEmpty<yaml_types::Swimlane> {
+        &self.swimlanes
     }
 }

--- a/src/diagram/svg.rs
+++ b/src/diagram/svg.rs
@@ -3,24 +3,47 @@
 //! This module provides functionality to render event model diagrams as SVG.
 
 use super::{EventModelDiagram, Result};
+use crate::event_model::yaml_types;
+use crate::infrastructure::types::NonEmpty;
 
 // Constants for SVG dimensions and text coordinates
-const DEFAULT_WIDTH: u32 = 1200;
-const DEFAULT_HEIGHT: u32 = 800;
-const MARGIN: u32 = 10;
-const TITLE_FONT_SIZE: u32 = 14;
-const TITLE_Y: u32 = 25;
+const MIN_WIDTH: u32 = 1200; // Minimum reasonable width
+const PADDING: u32 = 20; // Consistent padding around elements
+const TITLE_FONT_SIZE: u32 = 12;
+const TITLE_Y: u32 = 35;
+
+// Swimlane constants
+const MIN_SWIMLANE_HEIGHT: u32 = 200; // Minimum height for empty swimlane
+const SWIMLANE_LABEL_WIDTH: u32 = 80; // Width for rotated labels
+const SWIMLANE_LABEL_FONT_SIZE: u32 = 10;
+const HEADER_HEIGHT: u32 = 50; // Space for title area
 
 // Colors
 const BACKGROUND_COLOR: &str = "#f8f8f8"; // Light gray background
 const TEXT_COLOR: &str = "#333333"; // Dark gray text
+const SWIMLANE_BORDER_COLOR: &str = "#cccccc"; // Light gray for borders
 
 /// Renders an event model diagram to SVG format.
 ///
 /// This function takes a constructed diagram and produces the SVG representation.
 pub fn render_to_svg(diagram: &EventModelDiagram) -> Result<String> {
-    // Step 1: Canvas with workflow title
-    let svg = format!(
+    let swimlanes = diagram.swimlanes();
+    let num_swimlanes = swimlanes.len();
+
+    // Calculate dynamic dimensions
+    // TODO: In future steps, width will grow based on content
+    let total_width = MIN_WIDTH;
+
+    // Each swimlane gets minimum height for now
+    // TODO: In future steps, height will grow based on content in each swimlane
+    let swimlane_heights: Vec<u32> = vec![MIN_SWIMLANE_HEIGHT; num_swimlanes];
+    let total_swimlane_height: u32 = swimlane_heights.iter().sum();
+    let total_height = HEADER_HEIGHT + total_swimlane_height + PADDING;
+
+    let mut svg_content = String::new();
+
+    // SVG header
+    svg_content.push_str(&format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {} {}">
   <!-- Canvas background -->
@@ -30,18 +53,94 @@ pub fn render_to_svg(diagram: &EventModelDiagram) -> Result<String> {
   <text x="{}" y="{}" font-family="Arial, sans-serif" font-size="{}" font-weight="normal" fill="{}">
     {}
   </text>
-</svg>"#,
-        DEFAULT_WIDTH,
-        DEFAULT_HEIGHT,
-        DEFAULT_WIDTH,
-        DEFAULT_HEIGHT,
+"#,
+        total_width,
+        total_height,
+        total_width,
+        total_height,
         BACKGROUND_COLOR,
-        MARGIN,
+        PADDING,
         TITLE_Y,
         TITLE_FONT_SIZE,
         TEXT_COLOR,
         diagram.workflow_title().as_str()
-    );
+    ));
 
-    Ok(svg)
+    // Render swimlanes
+    svg_content.push_str(&render_swimlanes(
+        swimlanes,
+        &swimlane_heights,
+        HEADER_HEIGHT,
+        total_width,
+    ));
+
+    // Close SVG
+    svg_content.push_str("</svg>");
+
+    Ok(svg_content)
+}
+
+/// Renders the swimlanes with labels and dividers.
+fn render_swimlanes(
+    swimlanes: &NonEmpty<yaml_types::Swimlane>,
+    swimlane_heights: &[u32],
+    start_y: u32,
+    total_width: u32,
+) -> String {
+    let mut svg = String::new();
+
+    svg.push_str("  <!-- Swimlanes -->\n");
+
+    let mut current_y = start_y;
+
+    for (index, (swimlane, &height)) in swimlanes.iter().zip(swimlane_heights.iter()).enumerate() {
+        // Draw horizontal line (except for the first swimlane)
+        if index > 0 {
+            svg.push_str(&format!(
+                r#"  <line x1="{}" y1="{}" x2="{}" y2="{}" stroke="{}" stroke-width="1"/>
+"#,
+                0, current_y, total_width, current_y, SWIMLANE_BORDER_COLOR
+            ));
+        }
+
+        // Draw rotated label on the left
+        let label_x = SWIMLANE_LABEL_WIDTH / 2;
+        let label_y = current_y + (height / 2);
+
+        svg.push_str(&format!(
+            r#"  <text x="{}" y="{}" font-family="Arial, sans-serif" font-size="{}" fill="{}" text-anchor="middle" transform="rotate(-90 {} {})">
+    {}
+  </text>
+"#,
+            label_x,
+            label_y,
+            SWIMLANE_LABEL_FONT_SIZE,
+            TEXT_COLOR,
+            label_x,
+            label_y,
+            swimlane.name.clone().into_inner().as_str()
+        ));
+
+        // Draw vertical line to separate label area from content area
+        svg.push_str(&format!(
+            r#"  <line x1="{}" y1="{}" x2="{}" y2="{}" stroke="{}" stroke-width="1"/>
+"#,
+            SWIMLANE_LABEL_WIDTH,
+            current_y,
+            SWIMLANE_LABEL_WIDTH,
+            current_y + height,
+            SWIMLANE_BORDER_COLOR
+        ));
+
+        current_y += height;
+    }
+
+    // Draw bottom border
+    svg.push_str(&format!(
+        r#"  <line x1="{}" y1="{}" x2="{}" y2="{}" stroke="{}" stroke-width="1"/>
+"#,
+        0, current_y, total_width, current_y, SWIMLANE_BORDER_COLOR
+    ));
+
+    svg
 }


### PR DESCRIPTION
## Summary
- Implemented Phase 6 Step 2: All Swimlanes
- Renders swimlanes dynamically from the domain model
- Proper visual styling with rotated labels and dividers

## Changes
- Updated `EventModelDiagram` to include swimlanes from YAML model
- Implemented dynamic swimlane rendering with:
  - Variable number of swimlanes based on input file
  - Minimum height of 200px per swimlane (will grow with content in future steps)
  - Rotated labels on the left side
  - Clean visual separation between label area and content area
  - Proper borders and spacing matching the example style
- Updated PLANNING.md to clarify visual style requirements (dynamic sizing, not pixel-perfect matching)

## Visual Output
The diagram now renders:
- Light gray background (#f8f8f8)
- Workflow title at the top
- Dynamic number of swimlanes with labels from the .eventmodel file
- Proper visual hierarchy and spacing

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>