### PR TITLE
workflow_next doesn't detect when current branch has already been merged

### DIFF
--- a/mcp-workflow-server/src/tools/workflow-next.ts
+++ b/mcp-workflow-server/src/tools/workflow-next.ts
@@ -148,11 +148,24 @@ export async function workflowNext(): Promise<WorkflowNextResponse> {
       if (isMerged) {
         automaticActions.push(`Current branch '${currentBranch}' has been merged to main`);
         
+        const suggestedActions = [];
+        const issuesFound = [`Branch '${currentBranch}' has been merged - switch to main`];
+        
+        if (hasUncommittedChanges) {
+          issuesFound.push('You have uncommitted changes that need to be handled before switching branches');
+          suggestedActions.push('Commit or stash your changes: git commit -am "Save work" OR git stash');
+        }
+        
+        suggestedActions.push(
+          'Run: git checkout main && git pull origin main',
+          'Then run workflow_next again to find next task'
+        );
+        
         return {
           requestedData: {
             nextSteps: [{
               action: 'select_work',
-              suggestion: `Your branch '${currentBranch}' has been merged. Switch to main and pull latest changes before starting new work.`,
+              suggestion: `Your branch '${currentBranch}' has been merged. ${hasUncommittedChanges ? 'Commit or stash your changes, then s' : 'S'}witch to main and pull latest changes before starting new work.`,
               reason: 'Current branch has been merged to main'
             }],
             context: {
@@ -162,11 +175,8 @@ export async function workflowNext(): Promise<WorkflowNextResponse> {
             }
           },
           automaticActions,
-          issuesFound: [`Branch '${currentBranch}' has been merged - switch to main`],
-          suggestedActions: [
-            'Run: git checkout main && git pull origin main',
-            'Then run workflow_next again to find next task'
-          ],
+          issuesFound,
+          suggestedActions,
           allPRStatus: []
         };
       }

--- a/mcp-workflow-server/src/tools/workflow-status.ts
+++ b/mcp-workflow-server/src/tools/workflow-status.ts
@@ -1,5 +1,5 @@
 import { WorkflowResponse, PRStatus } from '../types.js';
-import { getGitStatus, isCurrentBranchStale } from '../utils/git.js';
+import { getGitStatus, isCurrentBranchStale, isBranchMerged } from '../utils/git.js';
 import { getAllPRs } from '../utils/github.js';
 import { StateStore } from '../state/store.js';
 
@@ -18,11 +18,18 @@ export async function workflowStatusTool(): Promise<WorkflowResponse> {
     const gitStatus = await getGitStatus();
     automaticActions.push('Checked git status and branch information');
     
-    // Check if branch is stale
+    // Check if branch is stale or merged
     const isStale = await isCurrentBranchStale();
-    if (isStale && gitStatus.currentBranch !== 'main') {
-      issuesFound.push(`Branch '${gitStatus.currentBranch}' may be stale (created before recent main merges)`);
-      suggestedActions.push('Consider rebasing on latest main or creating a fresh branch');
+    const isMerged = await isBranchMerged(gitStatus.currentBranch);
+    
+    if (gitStatus.currentBranch !== 'main') {
+      if (isMerged) {
+        issuesFound.push(`Branch '${gitStatus.currentBranch}' has been merged to main`);
+        suggestedActions.push('[NEXT] Switch to main: git checkout main && git pull origin main');
+      } else if (isStale) {
+        issuesFound.push(`Branch '${gitStatus.currentBranch}' may be stale (created before recent main merges)`);
+        suggestedActions.push('Consider rebasing on latest main or creating a fresh branch');
+      }
     }
     
     // Get all PRs
@@ -125,7 +132,7 @@ export async function workflowStatusTool(): Promise<WorkflowResponse> {
         suggestedActions.push('[NEXT] Create a new feature branch for your next task');
       } else if (allPRs.some(pr => pr.branch === gitStatus.currentBranch)) {
         suggestedActions.push('[NEXT] Continue implementing features on current branch');
-      } else {
+      } else if (!isMerged) {
         suggestedActions.push('[NEXT] Create a PR for your current branch');
       }
     }

--- a/mcp-workflow-server/src/tools/workflow-status.ts
+++ b/mcp-workflow-server/src/tools/workflow-status.ts
@@ -20,9 +20,9 @@ export async function workflowStatusTool(): Promise<WorkflowResponse> {
     
     // Check if branch is stale or merged
     const isStale = await isCurrentBranchStale();
-    const isMerged = await isBranchMerged(gitStatus.currentBranch);
     
     if (gitStatus.currentBranch !== 'main') {
+      const isMerged = await isBranchMerged(gitStatus.currentBranch);
       if (isMerged) {
         issuesFound.push(`Branch '${gitStatus.currentBranch}' has been merged to main`);
         suggestedActions.push('[NEXT] Switch to main: git checkout main && git pull origin main');
@@ -132,8 +132,12 @@ export async function workflowStatusTool(): Promise<WorkflowResponse> {
         suggestedActions.push('[NEXT] Create a new feature branch for your next task');
       } else if (allPRs.some(pr => pr.branch === gitStatus.currentBranch)) {
         suggestedActions.push('[NEXT] Continue implementing features on current branch');
-      } else if (!isMerged) {
-        suggestedActions.push('[NEXT] Create a PR for your current branch');
+      } else {
+        // Only suggest creating PR if branch isn't merged
+        const branchMerged = await isBranchMerged(gitStatus.currentBranch);
+        if (!branchMerged) {
+          suggestedActions.push('[NEXT] Create a PR for your current branch');
+        }
       }
     }
 

--- a/mcp-workflow-server/src/utils/git.ts
+++ b/mcp-workflow-server/src/utils/git.ts
@@ -80,3 +80,26 @@ export async function isCurrentBranchStale(): Promise<boolean> {
     return false;
   }
 }
+
+export async function isBranchMerged(branch?: string): Promise<boolean> {
+  try {
+    // Use current branch if not specified
+    const branchToCheck = branch || await git.revparse(['--abbrev-ref', 'HEAD']);
+    
+    if (branchToCheck.trim() === 'main') {
+      return true; // main is always "merged"
+    }
+    
+    // Check if all commits from the branch are in main
+    const unmergedCommits = await git.raw([
+      'rev-list',
+      '--count',
+      `origin/main..${branchToCheck}`,
+    ]);
+    
+    // If there are no unmerged commits, the branch has been merged
+    return parseInt(unmergedCommits.trim(), 10) === 0;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

This PR implements workflow_next doesn't detect when current branch has already been merged.

## Related Issue

Closes #78

## Changes

- Updated 3 files in `mcp-workflow-server/`

## Test Plan

Based on acceptance criteria:
- [ ] Add check to see if current branch has been merged to main
- [ ] Update suggestions to guide user to switch branches when on merged branch
- [ ] Test with various scenarios (merged, unmerged, diverged branches)

🤖 Generated with [MCP Workflow Server](https://github.com/jwilger/event_modeler)


<!-- DIAGRAM_START -->
## 📊 Event Model Diagram Preview

Generated from `tests/fixtures/acceptance/example.eventmodel`:

![Event Model Diagram](https://gist.githubusercontent.com/jwilger/47d0f80560da56690c12636f60d6ac5f/raw/example.svg)

> **View options:**
> - Click image to view full size
> - [Open in new tab](https://gist.githubusercontent.com/jwilger/47d0f80560da56690c12636f60d6ac5f/raw/example.svg)
> - [View gist](https://gist.github.com/47d0f80560da56690c12636f60d6ac5f)

### Current Progress: Step 2 - Swimlanes
✅ Workflow title
✅ Horizontal swimlanes with labels

---
🤖 *Generated by CI build #272*
<!-- DIAGRAM_END -->