### PR TITLE
workflow_decide should ensure branches are created from updated main

### DIFF
--- a/mcp-workflow-server/src/tools/workflow-decide.ts
+++ b/mcp-workflow-server/src/tools/workflow-decide.ts
@@ -230,8 +230,19 @@ export async function workflowDecide(input: DecisionInput): Promise<WorkflowDeci
         automaticActions.push(`Switched to existing branch: ${branchName}`);
         branchSwitched = true;
       } catch {
-        // Branch doesn't exist, create it
+        // Branch doesn't exist, ensure we're on an updated main before creating
         try {
+          // First, switch to main if we're not already there
+          if (currentBranch !== 'main') {
+            execSync('git checkout main', { encoding: 'utf8' });
+            automaticActions.push('Switched to main branch');
+          }
+          
+          // Pull latest changes from origin/main
+          execSync('git pull origin main', { encoding: 'utf8' });
+          automaticActions.push('Updated main branch with latest changes');
+          
+          // Now create the feature branch from updated main
           execSync(`git checkout -b ${branchName}`, { encoding: 'utf8' });
           automaticActions.push(`Created and switched to new branch: ${branchName}`);
           branchCreated = true;


### PR DESCRIPTION
## Summary

This PR implements workflow_decide should ensure branches are created from updated main.

## Related Issue

Closes #103

## Changes

- Updated `.../src/tools/__tests__/workflow-decide.test.ts`
- Updated `mcp-workflow-server/src/tools/workflow-decide.ts`

## Test Plan

Based on acceptance criteria:
- [ ] workflow_decide checks if on main before creating branches
- [ ] Automatically switches to main if no uncommitted changes
- [ ] Pulls latest from origin/main before creating branch
- [ ] Provides clear guidance when uncommitted changes prevent switching
- [ ] Feature branches are always created from updated main

🤖 Generated with [MCP Workflow Server](https://github.com/jwilger/event_modeler)
