### PR TITLE
MCP Tool: Manage GitHub sub-issues

### DIFF
--- a/mcp-workflow-server/src/__tests__/index.test.ts
+++ b/mcp-workflow-server/src/__tests__/index.test.ts
@@ -50,7 +50,7 @@ describe('MCP Server Index', () => {
     const result = await (listToolsHandler as () => Promise<{ tools: Tool[] }>)();
 
     // Verify all tools are registered
-    expect(result.tools).toHaveLength(7);
+    expect(result.tools).toHaveLength(8);
 
     // Find workflow_status tool
     const statusTool = result.tools.find((t: Tool) => t.name === 'workflow_status');

--- a/mcp-workflow-server/src/tools/__tests__/workflow-manage-subissues.test.ts
+++ b/mcp-workflow-server/src/tools/__tests__/workflow-manage-subissues.test.ts
@@ -270,7 +270,7 @@ describe('workflowManageSubissues', () => {
 
     it('should handle unknown action', async () => {
       const result = await workflowManageSubissues({
-        action: 'invalid' as any,
+        action: 'invalid' as 'link' | 'unlink' | 'list',
         epicNumber: 68,
       });
 

--- a/mcp-workflow-server/src/tools/__tests__/workflow-manage-subissues.test.ts
+++ b/mcp-workflow-server/src/tools/__tests__/workflow-manage-subissues.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { workflowManageSubissues } from '../workflow-manage-subissues.js';
+
+// Mock child_process
+vi.mock('child_process', () => ({
+  execSync: vi.fn((cmd: string) => {
+    if (cmd === 'gh auth token') return 'test-token';
+    if (cmd.startsWith('git remote get-url')) return 'https://github.com/testuser/testrepo.git';
+    return '';
+  }),
+}));
+
+// Mock @octokit/rest
+const mockGraphql = vi.fn();
+vi.mock('@octokit/rest', () => ({
+  Octokit: vi.fn(() => ({
+    graphql: mockGraphql,
+  })),
+}));
+
+// Mock github utils
+vi.mock('../../utils/github.js', () => ({
+  getRepoInfo: vi.fn(() => ({
+    owner: 'testuser',
+    repo: 'testrepo',
+  })),
+}));
+
+describe('workflowManageSubissues', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGraphql.mockReset();
+  });
+
+  describe('link action', () => {
+    it('should link an issue as a sub-issue to an epic', async () => {
+      // Mock getting node IDs
+      mockGraphql
+        .mockResolvedValueOnce({
+          repository: {
+            issue: {
+              id: 'epic-node-id',
+              title: 'Epic Issue',
+            },
+          },
+        })
+        .mockResolvedValueOnce({
+          repository: {
+            issue: {
+              id: 'issue-node-id',
+              title: 'Sub Issue',
+            },
+          },
+        })
+        // Mock circular dependency check
+        .mockResolvedValueOnce({
+          node: {
+            parentIssue: null,
+          },
+        })
+        // Mock linking mutation
+        .mockResolvedValueOnce({
+          addSubIssue: {
+            issue: { number: 68, title: 'Epic Issue' },
+            subIssue: { number: 123, title: 'Sub Issue' },
+          },
+        });
+
+      const result = await workflowManageSubissues({
+        action: 'link',
+        epicNumber: 68,
+        issueNumber: 123,
+      });
+
+      expect(result.requestedData.success).toBe(true);
+      expect(result.automaticActions).toContain('Successfully linked issue #123 to epic #68');
+      expect(mockGraphql).toHaveBeenCalledTimes(4);
+    });
+
+    it('should prevent circular dependencies', async () => {
+      // Mock getting node IDs
+      mockGraphql
+        .mockResolvedValueOnce({
+          repository: {
+            issue: {
+              id: 'epic-node-id',
+              title: 'Epic Issue',
+            },
+          },
+        })
+        .mockResolvedValueOnce({
+          repository: {
+            issue: {
+              id: 'issue-node-id',
+              title: 'Sub Issue',
+            },
+          },
+        })
+        // Mock circular dependency check - epic has issue as parent
+        .mockResolvedValueOnce({
+          node: {
+            parentIssue: {
+              id: 'issue-node-id',
+            },
+          },
+        });
+
+      const result = await workflowManageSubissues({
+        action: 'link',
+        epicNumber: 68,
+        issueNumber: 123,
+      });
+
+      expect(result.requestedData.success).toBe(false);
+      expect(result.requestedData.error).toContain('would create circular dependency');
+      expect(mockGraphql).toHaveBeenCalledTimes(3); // No linking mutation
+    });
+
+    it('should handle missing issue number for link action', async () => {
+      const result = await workflowManageSubissues({
+        action: 'link',
+        epicNumber: 68,
+      });
+
+      expect(result.requestedData.success).toBe(false);
+      expect(result.requestedData.error).toContain('issueNumber is required for link action');
+    });
+  });
+
+  describe('unlink action', () => {
+    it('should unlink a sub-issue from an epic', async () => {
+      // Mock getting node IDs
+      mockGraphql
+        .mockResolvedValueOnce({
+          repository: {
+            issue: {
+              id: 'epic-node-id',
+              title: 'Epic Issue',
+            },
+          },
+        })
+        .mockResolvedValueOnce({
+          repository: {
+            issue: {
+              id: 'issue-node-id',
+              title: 'Sub Issue',
+            },
+          },
+        })
+        // Mock unlinking mutation
+        .mockResolvedValueOnce({
+          removeSubIssue: {
+            issue: { number: 68, title: 'Epic Issue' },
+            subIssue: { number: 123, title: 'Sub Issue' },
+          },
+        });
+
+      const result = await workflowManageSubissues({
+        action: 'unlink',
+        epicNumber: 68,
+        issueNumber: 123,
+      });
+
+      expect(result.requestedData.success).toBe(true);
+      expect(result.automaticActions).toContain('Successfully unlinked issue #123 from epic #68');
+      expect(mockGraphql).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('list action', () => {
+    it('should list all sub-issues for an epic', async () => {
+      mockGraphql.mockResolvedValueOnce({
+        repository: {
+          issue: {
+            title: 'Epic: Test Epic',
+            subIssues: {
+              nodes: [
+                {
+                  number: 123,
+                  title: 'Sub Issue 1',
+                  state: 'OPEN',
+                  url: 'https://github.com/testuser/testrepo/issues/123',
+                  assignees: {
+                    nodes: [{ login: 'user1' }],
+                  },
+                },
+                {
+                  number: 124,
+                  title: 'Sub Issue 2',
+                  state: 'CLOSED',
+                  url: 'https://github.com/testuser/testrepo/issues/124',
+                  assignees: {
+                    nodes: [],
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+
+      const result = await workflowManageSubissues({
+        action: 'list',
+        epicNumber: 68,
+      });
+
+      expect(result.requestedData.success).toBe(true);
+      expect(result.requestedData.subIssues).toHaveLength(2);
+      expect(result.requestedData.subIssues![0]).toEqual({
+        number: 123,
+        title: 'Sub Issue 1',
+        state: 'OPEN',
+        url: 'https://github.com/testuser/testrepo/issues/123',
+        assignees: ['user1'],
+      });
+      expect(result.automaticActions).toContain('Found 2 sub-issues for epic #68');
+      expect(result.suggestedActions).toContain('🟢 #123: Sub Issue 1 (assigned to: user1)');
+      expect(result.suggestedActions).toContain('✅ #124: Sub Issue 2');
+    });
+
+    it('should handle epic with no sub-issues', async () => {
+      mockGraphql.mockResolvedValueOnce({
+        repository: {
+          issue: {
+            title: 'Epic: Empty Epic',
+            subIssues: {
+              nodes: [],
+            },
+          },
+        },
+      });
+
+      const result = await workflowManageSubissues({
+        action: 'list',
+        epicNumber: 68,
+      });
+
+      expect(result.requestedData.success).toBe(true);
+      expect(result.requestedData.subIssues).toHaveLength(0);
+      expect(result.automaticActions).toContain('Found 0 sub-issues for epic #68');
+    });
+
+    it('should handle non-existent epic', async () => {
+      mockGraphql.mockResolvedValueOnce({
+        repository: {
+          issue: null,
+        },
+      });
+
+      const result = await workflowManageSubissues({
+        action: 'list',
+        epicNumber: 999,
+      });
+
+      expect(result.requestedData.success).toBe(false);
+      expect(result.requestedData.error).toContain('Epic #999 not found');
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle missing required parameters', async () => {
+      const result = await workflowManageSubissues({
+        action: 'link',
+        epicNumber: 0, // Invalid
+      });
+
+      expect(result.requestedData.success).toBe(false);
+      expect(result.issuesFound).toHaveLength(1);
+    });
+
+    it('should handle unknown action', async () => {
+      const result = await workflowManageSubissues({
+        action: 'invalid' as any,
+        epicNumber: 68,
+      });
+
+      expect(result.requestedData.success).toBe(false);
+      expect(result.requestedData.error).toContain('Unknown action: invalid');
+    });
+
+    it('should handle GraphQL errors', async () => {
+      mockGraphql.mockRejectedValueOnce(new Error('GraphQL error'));
+
+      const result = await workflowManageSubissues({
+        action: 'list',
+        epicNumber: 68,
+      });
+
+      expect(result.requestedData.success).toBe(false);
+      expect(result.requestedData.error).toContain('GraphQL error');
+    });
+  });
+});

--- a/mcp-workflow-server/src/tools/workflow-manage-subissues.ts
+++ b/mcp-workflow-server/src/tools/workflow-manage-subissues.ts
@@ -1,0 +1,313 @@
+import { Octokit } from '@octokit/rest';
+import { execSync } from 'child_process';
+import { WorkflowResponse } from '../types.js';
+import { getRepoInfo } from '../utils/github.js';
+
+interface ManageSubissuesInput {
+  action: 'link' | 'unlink' | 'list';
+  epicNumber: number;
+  issueNumber?: number;
+}
+
+interface SubIssue {
+  number: number;
+  title: string;
+  state: string;
+  url: string;
+  assignees: string[];
+}
+
+interface WorkflowManageSubissuesResponse extends WorkflowResponse {
+  requestedData: {
+    action: string;
+    epicNumber: number;
+    issueNumber?: number;
+    success: boolean;
+    subIssues?: SubIssue[];
+    error?: string;
+  };
+}
+
+async function getIssueNodeId(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  issueNumber: number
+): Promise<string> {
+  const query = `
+    query GetIssueId($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        issue(number: $number) {
+          id
+          title
+        }
+      }
+    }
+  `;
+
+  const result = await octokit.graphql(query, {
+    owner,
+    repo,
+    number: issueNumber,
+  });
+
+  const issue = (result as any).repository.issue;
+  if (!issue) {
+    throw new Error(`Issue #${issueNumber} not found`);
+  }
+
+  return issue.id;
+}
+
+async function checkCircularDependency(
+  octokit: Octokit,
+  parentId: string,
+  childId: string
+): Promise<boolean> {
+  // Check if the child is already a parent of the parent (circular dependency)
+  const query = `
+    query CheckCircular($nodeId: ID!) {
+      node(id: $nodeId) {
+        ... on Issue {
+          parentIssue {
+            id
+          }
+        }
+      }
+    }
+  `;
+
+  // Check if parent has a parent that is the child (would create circular reference)
+  const result = await octokit.graphql(query, { nodeId: parentId });
+  const parentIssue = (result as any).node?.parentIssue;
+  
+  if (parentIssue && parentIssue.id === childId) {
+    return true; // Would create circular dependency
+  }
+
+  // TODO: Could implement deeper circular dependency checking if needed
+  return false;
+}
+
+export async function workflowManageSubissues(
+  input: ManageSubissuesInput
+): Promise<WorkflowManageSubissuesResponse> {
+  const automaticActions: string[] = [];
+  const issuesFound: string[] = [];
+  const suggestedActions: string[] = [];
+
+  try {
+    const { action, epicNumber, issueNumber } = input;
+
+    // Validate input
+    if (!action || !epicNumber) {
+      throw new Error('Missing required parameters: action and epicNumber are required');
+    }
+
+    if ((action === 'link' || action === 'unlink') && !issueNumber) {
+      throw new Error(`issueNumber is required for ${action} action`);
+    }
+
+    // Get repository info
+    const { owner, repo } = getRepoInfo();
+    automaticActions.push(`Working in repository: ${owner}/${repo}`);
+
+    // Set up GitHub API
+    const token = execSync('gh auth token', { encoding: 'utf8' }).trim();
+    const octokit = new Octokit({ auth: token });
+
+    if (action === 'link') {
+      automaticActions.push(`Linking issue #${issueNumber} as sub-issue of epic #${epicNumber}`);
+
+      // Get node IDs for both issues
+      const [epicNodeId, issueNodeId] = await Promise.all([
+        getIssueNodeId(octokit, owner, repo, epicNumber),
+        getIssueNodeId(octokit, owner, repo, issueNumber!),
+      ]);
+
+      // Check for circular dependency
+      const hasCircular = await checkCircularDependency(
+        octokit,
+        epicNodeId,
+        issueNodeId
+      );
+
+      if (hasCircular) {
+        throw new Error(
+          `Cannot link issue #${issueNumber} to epic #${epicNumber}: would create circular dependency`
+        );
+      }
+
+      // Link the sub-issue
+      const mutation = `
+        mutation LinkSubIssue($parentId: ID!, $childId: ID!) {
+          addSubIssue(input: { issueId: $parentId, subIssueId: $childId }) {
+            issue {
+              number
+              title
+            }
+            subIssue {
+              number
+              title
+            }
+          }
+        }
+      `;
+
+      await octokit.graphql(mutation, {
+        parentId: epicNodeId,
+        childId: issueNodeId,
+      });
+
+      automaticActions.push(`Successfully linked issue #${issueNumber} to epic #${epicNumber}`);
+      suggestedActions.push(`View epic #${epicNumber}: https://github.com/${owner}/${repo}/issues/${epicNumber}`);
+
+      return {
+        requestedData: {
+          action,
+          epicNumber,
+          issueNumber,
+          success: true,
+        },
+        automaticActions,
+        issuesFound,
+        suggestedActions,
+        allPRStatus: [],
+      };
+    } else if (action === 'unlink') {
+      automaticActions.push(`Unlinking issue #${issueNumber} from epic #${epicNumber}`);
+
+      // Get node IDs for both issues
+      const [epicNodeId, issueNodeId] = await Promise.all([
+        getIssueNodeId(octokit, owner, repo, epicNumber),
+        getIssueNodeId(octokit, owner, repo, issueNumber!),
+      ]);
+
+      // Unlink the sub-issue
+      const mutation = `
+        mutation UnlinkSubIssue($parentId: ID!, $childId: ID!) {
+          removeSubIssue(input: { issueId: $parentId, subIssueId: $childId }) {
+            issue {
+              number
+              title
+            }
+            subIssue {
+              number
+              title
+            }
+          }
+        }
+      `;
+
+      await octokit.graphql(mutation, {
+        parentId: epicNodeId,
+        childId: issueNodeId,
+      });
+
+      automaticActions.push(`Successfully unlinked issue #${issueNumber} from epic #${epicNumber}`);
+
+      return {
+        requestedData: {
+          action,
+          epicNumber,
+          issueNumber,
+          success: true,
+        },
+        automaticActions,
+        issuesFound,
+        suggestedActions,
+        allPRStatus: [],
+      };
+    } else if (action === 'list') {
+      automaticActions.push(`Listing sub-issues for epic #${epicNumber}`);
+
+      // Get sub-issues for the epic
+      const query = `
+        query GetSubIssues($owner: String!, $repo: String!, $number: Int!) {
+          repository(owner: $owner, name: $repo) {
+            issue(number: $number) {
+              title
+              subIssues(first: 100) {
+                nodes {
+                  number
+                  title
+                  state
+                  url
+                  assignees(first: 10) {
+                    nodes {
+                      login
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `;
+
+      const result = await octokit.graphql(query, {
+        owner,
+        repo,
+        number: epicNumber,
+      });
+
+      const epic = (result as any).repository.issue;
+      if (!epic) {
+        throw new Error(`Epic #${epicNumber} not found`);
+      }
+
+      const subIssues: SubIssue[] = epic.subIssues.nodes.map((issue: any) => ({
+        number: issue.number,
+        title: issue.title,
+        state: issue.state,
+        url: issue.url,
+        assignees: issue.assignees.nodes.map((a: any) => a.login),
+      }));
+
+      automaticActions.push(`Found ${subIssues.length} sub-issues for epic #${epicNumber}`);
+
+      if (subIssues.length > 0) {
+        suggestedActions.push(
+          ...subIssues.map(
+            (issue) =>
+              `${issue.state === 'OPEN' ? '🟢' : '✅'} #${issue.number}: ${issue.title}${
+                issue.assignees.length > 0 ? ` (assigned to: ${issue.assignees.join(', ')})` : ''
+              }`
+          )
+        );
+      }
+
+      return {
+        requestedData: {
+          action,
+          epicNumber,
+          success: true,
+          subIssues,
+        },
+        automaticActions,
+        issuesFound,
+        suggestedActions,
+        allPRStatus: [],
+      };
+    } else {
+      throw new Error(`Unknown action: ${action}`);
+    }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    issuesFound.push(`Error: ${errorMessage}`);
+
+    return {
+      requestedData: {
+        action: input.action,
+        epicNumber: input.epicNumber,
+        issueNumber: input.issueNumber,
+        success: false,
+        error: errorMessage,
+      },
+      automaticActions,
+      issuesFound,
+      suggestedActions: ['Check the error message and try again'],
+      allPRStatus: [],
+    };
+  }
+}


### PR DESCRIPTION
## Summary

This PR implements MCP Tool: Manage GitHub sub-issues.

## Commits

- Implement MCP tool for managing GitHub sub-issues
- Fix TypeScript linting errors

## Related Issue

Closes #81

## Changes

- Updated 2 files in `mcp-workflow-server/`
- Updated 2 files in `.../`

## Test Plan

Based on acceptance criteria:
- [ ] Tool can link issue to epic by numbers
- [ ] Tool can unlink sub-issues
- [ ] Tool can list all sub-issues for an epic
- [ ] Prevents circular dependencies
- [ ] Clear error messages for invalid operations

🤖 Generated with [MCP Workflow Server](https://github.com/jwilger/event_modeler)
