### PR TITLE
workflow_next should detect when in-progress issue has commits without PR

### DIFF
--- a/mcp-workflow-server/src/tools/__tests__/workflow-next.test.ts
+++ b/mcp-workflow-server/src/tools/__tests__/workflow-next.test.ts
@@ -615,4 +615,238 @@ describe('workflowNext', () => {
       suggestion: 'All sub-issues for this epic are complete. Consider marking the epic as done.'
     });
   });
+
+  it('should detect when current branch corresponds to in-progress issue without PR', async () => {
+    const { workflowNext } = await import('../workflow-next.js');
+    
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (cmd === 'gh auth token') return 'mock-token\n';
+      if (cmd === 'gh api user --jq .login') return 'testuser\n';
+      if (cmd === 'gh repo view --json owner,name') {
+        return JSON.stringify({ owner: { login: 'jwilger' }, name: 'event_modeler' });
+      }
+      if (cmd === 'git status --porcelain') return '';
+      if (cmd === 'git branch --show-current') return 'feature/some-feature-78\n';
+      if (cmd === 'git rev-list --count origin/main..HEAD') return '3\n'; // Has commits
+      if (cmd.startsWith('gh pr list --head')) return '[]';
+      return '';
+    });
+    
+    mockGraphql
+      .mockResolvedValueOnce({
+        user: {
+          projectV2: {
+            items: {
+              nodes: [{
+                id: 'test-item-id',
+                content: {
+                  number: 78,
+                  title: 'Test Issue #78',
+                  body: '## Tasks\n- [ ] Todo 1\n- [ ] Todo 2',
+                  state: 'OPEN',
+                  assignees: {
+                    nodes: [{ login: 'testuser' }]
+                  },
+                  labels: {
+                    nodes: []
+                  }
+                },
+                fieldValues: {
+                  nodes: [{
+                    name: 'In Progress',
+                    field: { name: 'Status' }
+                  }]
+                }
+              }]
+            }
+          }
+        }
+      })
+      .mockResolvedValueOnce({
+        repository: {
+          pullRequests: {
+            nodes: [] // No PR exists
+          }
+        }
+      });
+
+    const result = await workflowNext();
+
+    expect(result.requestedData.nextSteps).toHaveLength(1);
+    expect(result.requestedData.nextSteps[0]).toMatchObject({
+      action: 'todos_complete',
+      issueNumber: 78,
+      title: 'Test Issue #78',
+      suggestion: "You have commits for issue #78 on branch 'feature/some-feature-78'. Create a PR before moving to the next issue."
+    });
+    expect(result.issuesFound).toContain("Branch 'feature/some-feature-78' has commits but no PR");
+    expect(result.suggestedActions).toContain('Create a PR for issue #78');
+  });
+
+  it('should not suggest PR creation if branch has no commits', async () => {
+    const { workflowNext } = await import('../workflow-next.js');
+    
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (cmd === 'gh auth token') return 'mock-token\n';
+      if (cmd === 'gh api user --jq .login') return 'testuser\n';
+      if (cmd === 'gh repo view --json owner,name') {
+        return JSON.stringify({ owner: { login: 'jwilger' }, name: 'event_modeler' });
+      }
+      if (cmd === 'git status --porcelain') return '';
+      if (cmd === 'git branch --show-current') return 'feature/no-commits-78\n';
+      if (cmd === 'git rev-list --count origin/main..HEAD') return '0\n'; // No commits
+      if (cmd.startsWith('gh pr list --head')) return '[]';
+      return '';
+    });
+    
+    mockGraphql.mockResolvedValue({
+      user: {
+        projectV2: {
+          items: {
+            nodes: [{
+              id: 'test-item-id',
+              content: {
+                number: 78,
+                title: 'Test Issue #78',
+                body: '## Tasks\n- [ ] Todo 1\n- [ ] Todo 2',
+                state: 'OPEN',
+                assignees: {
+                  nodes: [{ login: 'testuser' }]
+                },
+                labels: {
+                  nodes: []
+                }
+              },
+              fieldValues: {
+                nodes: [{
+                  name: 'In Progress',
+                  field: { name: 'Status' }
+                }]
+              }
+            }]
+          }
+        }
+      }
+    });
+
+    const result = await workflowNext();
+
+    // Should proceed with normal todo workflow since there are no commits
+    expect(result.requestedData.nextSteps[0]).toMatchObject({
+      action: 'work_on_todo',
+      issueNumber: 78,
+      todoItem: 'Todo 1'
+    });
+  });
+
+  it('should handle various branch name patterns when extracting issue number', async () => {
+    const { workflowNext } = await import('../workflow-next.js');
+    
+    const testBranchNames = [
+      'feature/add-new-feature-123',
+      'fix/issue-456',
+      'bugfix/789-fix-something',
+      'issue-321',
+      'feat-999-new-thing',
+      'hotfix/urgent-555'
+    ];
+    
+    for (const branchName of testBranchNames) {
+      vi.clearAllMocks();
+      
+      const expectedIssueNumber = parseInt(branchName.match(/(\d+)/)![1], 10);
+      
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (cmd === 'gh auth token') return 'mock-token\n';
+        if (cmd === 'gh api user --jq .login') return 'testuser\n';
+        if (cmd === 'gh repo view --json owner,name') {
+          return JSON.stringify({ owner: { login: 'jwilger' }, name: 'event_modeler' });
+        }
+        if (cmd === 'git status --porcelain') return '';
+        if (cmd === 'git branch --show-current') return `${branchName}\n`;
+        if (cmd === 'git rev-list --count origin/main..HEAD') return '1\n';
+        if (cmd.startsWith('gh pr list --head')) return '[]';
+        return '';
+      });
+      
+      mockGraphql
+        .mockResolvedValueOnce({
+          user: {
+            projectV2: {
+              items: {
+                nodes: [{
+                  id: 'test-item-id',
+                  content: {
+                    number: expectedIssueNumber,
+                    title: `Test Issue #${expectedIssueNumber}`,
+                    body: '## Tasks\n- [ ] Todo',
+                    state: 'OPEN',
+                    assignees: {
+                      nodes: [{ login: 'testuser' }]
+                    },
+                    labels: {
+                      nodes: []
+                    }
+                  },
+                  fieldValues: {
+                    nodes: [{
+                      name: 'In Progress',
+                      field: { name: 'Status' }
+                    }]
+                  }
+                }]
+              }
+            }
+          }
+        })
+        .mockResolvedValueOnce({
+          repository: {
+            pullRequests: {
+              nodes: []
+            }
+          }
+        });
+
+      const result = await workflowNext();
+      
+      expect(result.automaticActions).toContain(
+        `Detected issue #${expectedIssueNumber} from branch name: ${branchName}`
+      );
+    }
+  });
+
+  it('should ignore branch if issue number is not in progress', async () => {
+    const { workflowNext } = await import('../workflow-next.js');
+    
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (cmd === 'gh auth token') return 'mock-token\n';
+      if (cmd === 'gh api user --jq .login') return 'testuser\n';
+      if (cmd === 'gh repo view --json owner,name') {
+        return JSON.stringify({ owner: { login: 'jwilger' }, name: 'event_modeler' });
+      }
+      if (cmd === 'git status --porcelain') return '';
+      if (cmd === 'git branch --show-current') return 'feature/not-in-progress-99\n';
+      if (cmd === 'git rev-list --count origin/main..HEAD') return '1\n';
+      if (cmd.startsWith('gh pr list --head')) return '[]';
+      return '';
+    });
+    
+    mockGraphql.mockResolvedValue({
+      user: {
+        projectV2: {
+          items: {
+            nodes: [] // No issues in progress
+          }
+        }
+      }
+    });
+
+    const result = await workflowNext();
+
+    // Should not suggest PR creation since issue is not in progress
+    expect(result.requestedData.nextSteps[0]).toMatchObject({
+      action: 'select_work',
+      reason: 'No issues in progress. Visit project board to select next item.'
+    });
+  });
 });


### PR DESCRIPTION
## Summary

This PR implements workflow_next should detect when in-progress issue has commits without PR.

## Related Issue

Closes #83

## Changes

- Updated `.../src/tools/__tests__/workflow-next.test.ts`
- Updated `mcp-workflow-server/src/tools/workflow-next.ts`

## Test Plan

Based on acceptance criteria:
- [ ] Parse branch name to find issue number (e.g., fix/some-feature-78 -> issue #78)
- [ ] Check if parsed issue is in "In Progress" status
- [ ] If yes, check for existing PR and suggest creating one if none exists
- [ ] Only suggest next work after current issue has PR

🤖 Generated with [MCP Workflow Server](https://github.com/jwilger/event_modeler)


<!-- DIAGRAM_START -->
## 📊 Event Model Diagram Preview

Generated from `tests/fixtures/acceptance/example.eventmodel`:

![Event Model Diagram](https://gist.githubusercontent.com/jwilger/2174dc52c90a63117ee1edff0fc10861/raw/example.svg)

> **View options:**
> - Click image to view full size
> - [Open in new tab](https://gist.githubusercontent.com/jwilger/2174dc52c90a63117ee1edff0fc10861/raw/example.svg)
> - [View gist](https://gist.github.com/2174dc52c90a63117ee1edff0fc10861)

### Current Progress: Step 2 - Swimlanes
✅ Workflow title
✅ Horizontal swimlanes with labels

---
🤖 *Generated by CI build #308*
<!-- DIAGRAM_END -->