### PR TITLE
MCP Tool: Request re-review from specific reviewers

### DIFF
--- a/mcp-workflow-server/src/__tests__/index.test.ts
+++ b/mcp-workflow-server/src/__tests__/index.test.ts
@@ -49,8 +49,8 @@ describe('MCP Server Index', () => {
     // Call the handler to get the tools list
     const result = await (listToolsHandler as () => Promise<{ tools: Tool[] }>)();
 
-    // Verify all tools are registered (including workflow_create_issue tool)
-    expect(result.tools).toHaveLength(12);
+    // Verify all tools are registered (including workflow_create_issue and workflow_request_review tools)
+    expect(result.tools).toHaveLength(13);
 
     // Find workflow_status tool
     const statusTool = result.tools.find((t: Tool) => t.name === 'workflow_status');

--- a/mcp-workflow-server/src/index.ts
+++ b/mcp-workflow-server/src/index.ts
@@ -10,6 +10,7 @@ import { workflowConfigure } from './tools/workflow-configure.js';
 import { workflowCreatePR } from './tools/workflow-create-pr.js';
 import { workflowMonitorReviews } from './tools/workflow-monitor-reviews.js';
 import { workflowReplyReview, workflowReplyReviewTool } from './tools/workflow-reply-review.js';
+import { workflowRequestReview, workflowRequestReviewTool } from './tools/workflow-request-review.js';
 import { workflowManageSubissues } from './tools/workflow-manage-subissues.js';
 import { workflowCreateIssue } from './tools/workflow-create-issue.js';
 import { gitBranch } from './tools/git-branch.js';
@@ -150,6 +151,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         },
       },
       workflowReplyReviewTool,
+      workflowRequestReviewTool,
       {
         name: 'workflow_manage_subissues',
         description:
@@ -346,6 +348,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         break;
       case 'workflow_reply_review':
         result = await workflowReplyReview(request.params.arguments as { prNumber: number; commentId: number; body: string });
+        break;
+      case 'workflow_request_review':
+        result = await workflowRequestReview(request.params.arguments as { prNumber: number; reviewers?: string[]; skipBots?: boolean });
         break;
       case 'workflow_manage_subissues':
         result = await workflowManageSubissues(request.params.arguments as { action: 'link' | 'unlink' | 'list'; epicNumber: number; issueNumber?: number });

--- a/mcp-workflow-server/src/tools/__tests__/workflow-request-review.test.ts
+++ b/mcp-workflow-server/src/tools/__tests__/workflow-request-review.test.ts
@@ -1,0 +1,474 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { workflowRequestReview } from "../workflow-request-review.js";
+import { execSync } from "child_process";
+import { Octokit } from "@octokit/rest";
+
+vi.mock("child_process");
+vi.mock("@octokit/rest");
+vi.mock("../../utils/github.js", () => ({
+  getRepoInfo: (): { owner: string; repo: string } => ({ owner: "test-owner", repo: "test-repo" }),
+}));
+
+interface MockOctokit {
+  pulls: {
+    get: ReturnType<typeof vi.fn>;
+    requestReviewers: ReturnType<typeof vi.fn>;
+  };
+  graphql: ReturnType<typeof vi.fn>;
+}
+
+describe("workflowRequestReview", () => {
+  let mockOctokit: MockOctokit;
+  let mockExecSync: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecSync = vi.mocked(execSync);
+    mockExecSync.mockReturnValue("test-token");
+
+    mockOctokit = {
+      pulls: {
+        get: vi.fn(),
+        requestReviewers: vi.fn(),
+      },
+      graphql: vi.fn(),
+    };
+    vi.mocked(Octokit).mockImplementation(() => mockOctokit as unknown as Octokit);
+  });
+
+  it("should request reviews from all previous reviewers by default", async (): Promise<void> => {
+    // Mock PR data
+    mockOctokit.pulls.get.mockResolvedValue({
+      data: {
+        number: 123,
+        state: "open",
+        node_id: "PR_123",
+        html_url: "https://github.com/test-owner/test-repo/pull/123",
+        user: { login: "author" },
+      },
+    });
+
+    // Mock GraphQL response with reviewers
+    mockOctokit.graphql.mockResolvedValueOnce({
+      repository: {
+        pullRequest: {
+          reviewRequests: {
+            nodes: [
+              {
+                requestedReviewer: {
+                  login: "reviewer1",
+                  id: "USER_1",
+                  databaseId: 1,
+                },
+              },
+            ],
+          },
+          reviews: {
+            nodes: [
+              {
+                author: {
+                  login: "reviewer2",
+                  id: "USER_2",
+                  databaseId: 2,
+                },
+                state: "COMMENTED",
+              },
+            ],
+          },
+          reviewThreads: {
+            nodes: [
+              {
+                comments: {
+                  nodes: [
+                    {
+                      author: {
+                        login: "reviewer3",
+                        id: "USER_3",
+                        databaseId: 3,
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    // Mock successful review requests
+    mockOctokit.pulls.requestReviewers.mockResolvedValue({});
+
+    const result = await workflowRequestReview({
+      prNumber: 123,
+    });
+
+    expect(result.requestedData).toEqual({
+      prNumber: 123,
+      reviewersRequested: ["reviewer1", "reviewer2", "reviewer3"],
+      reviewersFailed: [],
+      prUrl: "https://github.com/test-owner/test-repo/pull/123",
+    });
+    expect(result.automaticActions).toContain(
+      "Found 3 previous reviewers on PR #123"
+    );
+    expect(mockOctokit.pulls.requestReviewers).toHaveBeenCalledTimes(3);
+  });
+
+  it("should request specific reviewers when provided", async (): Promise<void> => {
+    mockOctokit.pulls.get.mockResolvedValue({
+      data: {
+        number: 123,
+        state: "open",
+        node_id: "PR_123",
+        html_url: "https://github.com/test-owner/test-repo/pull/123",
+        user: { login: "author" },
+      },
+    });
+
+    mockOctokit.graphql.mockResolvedValueOnce({
+      repository: {
+        pullRequest: {
+          reviewRequests: { nodes: [] },
+          reviews: {
+            nodes: [
+              {
+                author: {
+                  login: "reviewer1",
+                  id: "USER_1",
+                  databaseId: 1,
+                },
+                state: "COMMENTED",
+              },
+              {
+                author: {
+                  login: "reviewer2",
+                  id: "USER_2",
+                  databaseId: 2,
+                },
+                state: "COMMENTED",
+              },
+            ],
+          },
+          reviewThreads: { nodes: [] },
+        },
+      },
+    });
+
+    mockOctokit.pulls.requestReviewers.mockResolvedValue({});
+
+    const result = await workflowRequestReview({
+      prNumber: 123,
+      reviewers: ["reviewer1"],
+    });
+
+    expect(result.requestedData).toEqual({
+      prNumber: 123,
+      reviewersRequested: ["reviewer1"],
+      reviewersFailed: [],
+      prUrl: "https://github.com/test-owner/test-repo/pull/123",
+    });
+    expect(mockOctokit.pulls.requestReviewers).toHaveBeenCalledTimes(1);
+    expect(mockOctokit.pulls.requestReviewers).toHaveBeenCalledWith({
+      owner: "test-owner",
+      repo: "test-repo",
+      pull_number: 123,
+      reviewers: ["reviewer1"],
+    });
+  });
+
+  it("should skip bot reviewers when skipBots is true", async (): Promise<void> => {
+    mockOctokit.pulls.get.mockResolvedValue({
+      data: {
+        number: 123,
+        state: "open",
+        node_id: "PR_123",
+        html_url: "https://github.com/test-owner/test-repo/pull/123",
+        user: { login: "author" },
+      },
+    });
+
+    mockOctokit.graphql.mockResolvedValueOnce({
+      repository: {
+        pullRequest: {
+          reviewRequests: { nodes: [] },
+          reviews: {
+            nodes: [
+              {
+                author: {
+                  login: "human-reviewer",
+                  id: "USER_1",
+                  databaseId: 1,
+                },
+                state: "COMMENTED",
+              },
+              {
+                author: {
+                  login: "bot-reviewer",
+                  id: "BOT_123",
+                  databaseId: 123,
+                },
+                state: "COMMENTED",
+              },
+            ],
+          },
+          reviewThreads: { nodes: [] },
+        },
+      },
+    });
+
+    mockOctokit.pulls.requestReviewers.mockResolvedValue({});
+
+    const result = await workflowRequestReview({
+      prNumber: 123,
+      skipBots: true,
+    });
+
+    expect(result.requestedData).toEqual({
+      prNumber: 123,
+      reviewersRequested: ["human-reviewer"],
+      reviewersFailed: [],
+      prUrl: "https://github.com/test-owner/test-repo/pull/123",
+    });
+    expect(result.automaticActions).toContain(
+      "Skipping bot reviewers: bot-reviewer"
+    );
+    expect(mockOctokit.pulls.requestReviewers).toHaveBeenCalledTimes(1);
+  });
+
+  it("should handle bot reviewers with GraphQL mutation", async (): Promise<void> => {
+    mockOctokit.pulls.get.mockResolvedValue({
+      data: {
+        number: 123,
+        state: "open",
+        node_id: "PR_123",
+        html_url: "https://github.com/test-owner/test-repo/pull/123",
+        user: { login: "author" },
+      },
+    });
+
+    mockOctokit.graphql
+      .mockResolvedValueOnce({
+        // First call - get reviewers
+        repository: {
+          pullRequest: {
+            reviewRequests: { nodes: [] },
+            reviews: {
+              nodes: [
+                {
+                  author: {
+                    login: "dependabot[bot]",
+                    id: "BOT_456",
+                    databaseId: 456,
+                  },
+                  state: "COMMENTED",
+                },
+              ],
+            },
+            reviewThreads: { nodes: [] },
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        // Second call - request review mutation
+        requestReviews: {
+          pullRequest: {
+            id: "PR_123",
+          },
+        },
+      });
+
+    const result = await workflowRequestReview({
+      prNumber: 123,
+      skipBots: false,
+    });
+
+    expect(result.requestedData).toEqual({
+      prNumber: 123,
+      reviewersRequested: ["dependabot[bot]"],
+      reviewersFailed: [],
+      prUrl: "https://github.com/test-owner/test-repo/pull/123",
+    });
+    expect(mockOctokit.graphql).toHaveBeenCalledTimes(2);
+    // Check that GraphQL mutation was called
+    expect(mockOctokit.graphql).toHaveBeenCalledWith(
+      expect.stringContaining("mutation"),
+      expect.objectContaining({
+        pullRequestId: "PR_123",
+        userIds: ["BOT_456"],
+      })
+    );
+  });
+
+  it("should handle closed PR error", async (): Promise<void> => {
+    mockOctokit.pulls.get.mockResolvedValue({
+      data: {
+        number: 123,
+        state: "closed",
+        node_id: "PR_123",
+        html_url: "https://github.com/test-owner/test-repo/pull/123",
+        user: { login: "author" },
+      },
+    });
+
+    const result = await workflowRequestReview({
+      prNumber: 123,
+    });
+
+    expect(result.requestedData).toBeNull();
+    expect(result.issuesFound).toContain(
+      "PR #123 is not open (state: closed)"
+    );
+  });
+
+  it("should handle reviewer not found", async (): Promise<void> => {
+    mockOctokit.pulls.get.mockResolvedValue({
+      data: {
+        number: 123,
+        state: "open",
+        node_id: "PR_123",
+        html_url: "https://github.com/test-owner/test-repo/pull/123",
+        user: { login: "author" },
+      },
+    });
+
+    mockOctokit.graphql.mockResolvedValueOnce({
+      repository: {
+        pullRequest: {
+          reviewRequests: { nodes: [] },
+          reviews: {
+            nodes: [
+              {
+                author: {
+                  login: "existing-reviewer",
+                  id: "USER_1",
+                  databaseId: 1,
+                },
+                state: "COMMENTED",
+              },
+            ],
+          },
+          reviewThreads: { nodes: [] },
+        },
+      },
+    });
+
+    const result = await workflowRequestReview({
+      prNumber: 123,
+      reviewers: ["non-existent-reviewer"],
+    });
+
+    expect(result.issuesFound).toContain(
+      "These reviewers were not found in PR history: non-existent-reviewer"
+    );
+  });
+
+  it("should handle already requested error gracefully", async (): Promise<void> => {
+    mockOctokit.pulls.get.mockResolvedValue({
+      data: {
+        number: 123,
+        state: "open",
+        node_id: "PR_123",
+        html_url: "https://github.com/test-owner/test-repo/pull/123",
+        user: { login: "author" },
+      },
+    });
+
+    mockOctokit.graphql.mockResolvedValueOnce({
+      repository: {
+        pullRequest: {
+          reviewRequests: { nodes: [] },
+          reviews: {
+            nodes: [
+              {
+                author: {
+                  login: "reviewer1",
+                  id: "USER_1",
+                  databaseId: 1,
+                },
+                state: "COMMENTED",
+              },
+            ],
+          },
+          reviewThreads: { nodes: [] },
+        },
+      },
+    });
+
+    mockOctokit.pulls.requestReviewers.mockRejectedValue(
+      new Error("Review has already been requested from reviewer1")
+    );
+
+    const result = await workflowRequestReview({
+      prNumber: 123,
+    });
+
+    expect(result.requestedData).toEqual({
+      prNumber: 123,
+      reviewersRequested: ["reviewer1"],
+      reviewersFailed: [],
+      prUrl: "https://github.com/test-owner/test-repo/pull/123",
+    });
+    expect(result.automaticActions).toContain(
+      "reviewer1 already has a pending review request"
+    );
+  });
+
+  it("should filter out PR author from reviewers", async (): Promise<void> => {
+    mockOctokit.pulls.get.mockResolvedValue({
+      data: {
+        number: 123,
+        state: "open",
+        node_id: "PR_123",
+        html_url: "https://github.com/test-owner/test-repo/pull/123",
+        user: { login: "pr-author" },
+      },
+    });
+
+    mockOctokit.graphql.mockResolvedValueOnce({
+      repository: {
+        pullRequest: {
+          reviewRequests: { nodes: [] },
+          reviews: {
+            nodes: [
+              {
+                author: {
+                  login: "pr-author",
+                  id: "USER_1",
+                  databaseId: 1,
+                },
+                state: "COMMENTED",
+              },
+              {
+                author: {
+                  login: "other-reviewer",
+                  id: "USER_2", 
+                  databaseId: 2,
+                },
+                state: "COMMENTED",
+              },
+            ],
+          },
+          reviewThreads: { nodes: [] },
+        },
+      },
+    });
+
+    mockOctokit.pulls.requestReviewers.mockResolvedValue({});
+
+    const result = await workflowRequestReview({
+      prNumber: 123,
+    });
+
+    expect(result.requestedData?.reviewersRequested).toEqual([
+      "other-reviewer",
+    ]);
+    expect(mockOctokit.pulls.requestReviewers).toHaveBeenCalledTimes(1);
+    expect(mockOctokit.pulls.requestReviewers).toHaveBeenCalledWith({
+      owner: "test-owner",
+      repo: "test-repo",
+      pull_number: 123,
+      reviewers: ["other-reviewer"],
+    });
+  });
+});

--- a/mcp-workflow-server/src/tools/workflow-request-review.ts
+++ b/mcp-workflow-server/src/tools/workflow-request-review.ts
@@ -1,0 +1,376 @@
+import { z } from "zod";
+import { execSync } from "child_process";
+import { Octokit } from "@octokit/rest";
+import { getRepoInfo } from "../utils/github.js";
+import type { WorkflowResponse } from "../types.js";
+
+// GraphQL response types
+interface GitHubUser {
+  login: string;
+  id: string;
+  databaseId: number;
+}
+
+interface ReviewRequest {
+  requestedReviewer: GitHubUser | null;
+}
+
+interface Review {
+  author: GitHubUser | null;
+  state: string;
+}
+
+interface ReviewComment {
+  author: GitHubUser | null;
+}
+
+interface ReviewThread {
+  comments: {
+    nodes: ReviewComment[];
+  };
+}
+
+interface PullRequestGraphQLResponse {
+  repository: {
+    pullRequest: {
+      reviewRequests: {
+        nodes: ReviewRequest[];
+      };
+      reviews: {
+        nodes: Review[];
+      };
+      reviewThreads: {
+        nodes: ReviewThread[];
+      };
+    };
+  };
+}
+
+const RequestReviewInputSchema = z.object({
+  prNumber: z.number().describe("Pull request number"),
+  reviewers: z
+    .array(z.string())
+    .optional()
+    .describe("Specific reviewers to request (optional - defaults to all previous reviewers)"),
+  skipBots: z
+    .boolean()
+    .optional()
+    .describe("Skip bot reviewers like Copilot (default: true)"),
+});
+
+type RequestReviewInput = z.infer<typeof RequestReviewInputSchema>;
+
+// Known bot IDs that are auto-requested by repo rules
+const COPILOT_BOT_ID = "BOT_kgDOCnlnWA";
+const AUTO_REQUESTED_BOTS = [COPILOT_BOT_ID];
+
+interface ReviewerInfo {
+  login: string;
+  id: string;
+  isBot: boolean;
+  nodeId: string;
+}
+
+export async function workflowRequestReview(
+  input: RequestReviewInput
+): Promise<WorkflowResponse> {
+  const { prNumber, reviewers: specificReviewers, skipBots = true } = input;
+  const automaticActions: string[] = [];
+  const issuesFound: string[] = [];
+  const suggestedActions: string[] = [];
+
+  try {
+    // Get GitHub token
+    const token = execSync("gh auth token", { encoding: "utf8" }).trim();
+    const octokit = new Octokit({ auth: token });
+    const { owner, repo } = getRepoInfo();
+
+    automaticActions.push(`Working in repository: ${owner}/${repo}`);
+
+    // Get PR details including previous reviewers
+    const { data: pr } = await octokit.pulls.get({
+      owner,
+      repo,
+      pull_number: prNumber,
+    });
+
+    if (pr.state !== "open") {
+      issuesFound.push(`PR #${prNumber} is not open (state: ${pr.state})`);
+      return {
+        requestedData: null,
+        automaticActions,
+        issuesFound,
+        suggestedActions,
+        allPRStatus: [],
+      };
+    }
+
+    // Get review history using GraphQL to identify all reviewers
+    const query = `
+      query($owner: String!, $repo: String!, $number: Int!) {
+        repository(owner: $owner, name: $repo) {
+          pullRequest(number: $number) {
+            reviewRequests(first: 100) {
+              nodes {
+                requestedReviewer {
+                  ... on User {
+                    login
+                    id
+                    databaseId
+                  }
+                  ... on Bot {
+                    login
+                    id
+                    databaseId
+                  }
+                }
+              }
+            }
+            reviews(first: 100) {
+              nodes {
+                author {
+                  login
+                  ... on User {
+                    id
+                    databaseId
+                  }
+                  ... on Bot {
+                    id
+                    databaseId
+                  }
+                }
+                state
+              }
+            }
+            reviewThreads(first: 100) {
+              nodes {
+                comments(first: 100) {
+                  nodes {
+                    author {
+                      login
+                      ... on User {
+                        id
+                        databaseId
+                      }
+                      ... on Bot {
+                        id
+                        databaseId
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    `;
+
+    const graphqlResponse = await octokit.graphql<PullRequestGraphQLResponse>(query, {
+      owner,
+      repo,
+      number: prNumber,
+    });
+
+    const pullRequest = graphqlResponse.repository.pullRequest;
+    const allReviewers = new Map<string, ReviewerInfo>();
+
+    // Collect reviewers from review requests
+    pullRequest.reviewRequests.nodes.forEach((node) => {
+      if (node.requestedReviewer) {
+        const reviewer = node.requestedReviewer;
+        const isBot = reviewer.id.startsWith("BOT_");
+        allReviewers.set(reviewer.login, {
+          login: reviewer.login,
+          id: reviewer.id,
+          isBot,
+          nodeId: reviewer.id,
+        });
+      }
+    });
+
+    // Collect reviewers from actual reviews
+    pullRequest.reviews.nodes.forEach((review) => {
+      if (review.author) {
+        const isBot = review.author.id.startsWith("BOT_");
+        allReviewers.set(review.author.login, {
+          login: review.author.login,
+          id: review.author.id,
+          isBot,
+          nodeId: review.author.id,
+        });
+      }
+    });
+
+    // Collect reviewers from review comments
+    pullRequest.reviewThreads.nodes.forEach((thread) => {
+      thread.comments.nodes.forEach((comment) => {
+        if (comment.author) {
+          const isBot = comment.author.id.startsWith("BOT_");
+          allReviewers.set(comment.author.login, {
+            login: comment.author.login,
+            id: comment.author.id,
+            isBot,
+            nodeId: comment.author.id,
+          });
+        }
+      });
+    });
+
+    // Remove PR author from reviewers
+    allReviewers.delete(pr.user?.login || "");
+
+    automaticActions.push(
+      `Found ${allReviewers.size} previous reviewers on PR #${prNumber}`
+    );
+
+    // Filter reviewers based on input
+    let reviewersToRequest: ReviewerInfo[] = [];
+
+    if (specificReviewers && specificReviewers.length > 0) {
+      // Use specific reviewers if provided
+      reviewersToRequest = specificReviewers
+        .map((login) => allReviewers.get(login))
+        .filter((r): r is ReviewerInfo => r !== undefined);
+
+      const notFound = specificReviewers.filter(
+        (login) => !allReviewers.has(login)
+      );
+      if (notFound.length > 0) {
+        issuesFound.push(
+          `These reviewers were not found in PR history: ${notFound.join(", ")}`
+        );
+      }
+    } else {
+      // Use all previous reviewers
+      reviewersToRequest = Array.from(allReviewers.values());
+    }
+
+    // Filter out bots if requested
+    if (skipBots) {
+      const botsToSkip = reviewersToRequest.filter((r) => r.isBot);
+      reviewersToRequest = reviewersToRequest.filter((r) => !r.isBot);
+      
+      if (botsToSkip.length > 0) {
+        automaticActions.push(
+          `Skipping bot reviewers: ${botsToSkip.map((b) => b.login).join(", ")}`
+        );
+      }
+    }
+
+    // Filter out auto-requested bots (like Copilot)
+    reviewersToRequest = reviewersToRequest.filter(
+      (r) => !AUTO_REQUESTED_BOTS.includes(r.nodeId)
+    );
+
+    if (reviewersToRequest.length === 0) {
+      issuesFound.push("No reviewers to request after filtering");
+      return {
+        requestedData: {
+          prNumber,
+          reviewersRequested: [],
+        },
+        automaticActions,
+        issuesFound,
+        suggestedActions,
+        allPRStatus: [],
+      };
+    }
+
+    // Request reviews
+    const requestedReviewers: string[] = [];
+    const failedRequests: string[] = [];
+
+    for (const reviewer of reviewersToRequest) {
+      try {
+        if (reviewer.isBot) {
+          // Use GraphQL mutation for bot reviewers
+          const mutation = `
+            mutation($pullRequestId: ID!, $userIds: [ID!]) {
+              requestReviews(input: {
+                pullRequestId: $pullRequestId,
+                userIds: $userIds
+              }) {
+                pullRequest {
+                  id
+                }
+              }
+            }
+          `;
+
+          await octokit.graphql(mutation, {
+            pullRequestId: pr.node_id,
+            userIds: [reviewer.nodeId],
+          });
+        } else {
+          // Use REST API for human reviewers
+          await octokit.pulls.requestReviewers({
+            owner,
+            repo,
+            pull_number: prNumber,
+            reviewers: [reviewer.login],
+          });
+        }
+        requestedReviewers.push(reviewer.login);
+        automaticActions.push(`Requested review from ${reviewer.login}`);
+      } catch (error) {
+        // Check if already requested or other common errors
+        const errorMessage = error instanceof Error ? error.message : 'unknown error';
+        if (errorMessage.includes("Review has already been requested")) {
+          automaticActions.push(
+            `${reviewer.login} already has a pending review request`
+          );
+          requestedReviewers.push(reviewer.login);
+        } else if (errorMessage.includes("not a collaborator")) {
+          failedRequests.push(`${reviewer.login} (not a collaborator)`);
+        } else {
+          failedRequests.push(
+            `${reviewer.login} (${errorMessage})`
+          );
+        }
+      }
+    }
+
+    if (failedRequests.length > 0) {
+      issuesFound.push(
+        `Failed to request reviews from: ${failedRequests.join(", ")}`
+      );
+    }
+
+    if (requestedReviewers.length > 0) {
+      suggestedActions.push(
+        `Successfully requested ${requestedReviewers.length} review(s)`
+      );
+    }
+
+    return {
+      requestedData: {
+        prNumber,
+        reviewersRequested: requestedReviewers,
+        reviewersFailed: failedRequests,
+        prUrl: pr.html_url,
+      },
+      automaticActions,
+      issuesFound,
+      suggestedActions,
+      allPRStatus: [],
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+    issuesFound.push(`Error: ${errorMessage}`);
+    return {
+      requestedData: null,
+      automaticActions,
+      issuesFound,
+      suggestedActions,
+      allPRStatus: [],
+    };
+  }
+}
+
+export const workflowRequestReviewTool = {
+  name: "mcp__workflow__workflow_request_review",
+  description:
+    "Request re-review from specific reviewers or all previous reviewers on a pull request",
+  inputSchema: RequestReviewInputSchema,
+};


### PR DESCRIPTION
## Summary

This PR implements MCP Tool: Request re-review from specific reviewers.

## Related Issue

Closes #92

## Changes

- Updated 2 files in `mcp-workflow-server/`
- Updated 2 files in `.../`

## Test Plan

Based on acceptance criteria:
- [ ] Identifies previous reviewers automatically
- [ ] Requests re-review via API
- [ ] Handles user and bot reviewers
- [ ] Provides feedback on request status
- [ ] Integrates with workflow after pushing fixes

🤖 Generated with [MCP Workflow Server](https://github.com/jwilger/event_modeler)
