### PR TITLE
MCP Tool: Update GitHub issue project fields

### DIFF
--- a/mcp-workflow-server/src/__tests__/index.test.ts
+++ b/mcp-workflow-server/src/__tests__/index.test.ts
@@ -49,8 +49,8 @@ describe('MCP Server Index', () => {
     // Call the handler to get the tools list
     const result = await (listToolsHandler as () => Promise<{ tools: Tool[] }>)();
 
-    // Verify all tools are registered (including workflow_create_issue and workflow_request_review tools)
-    expect(result.tools).toHaveLength(13);
+    // Verify all tools are registered (including workflow_create_issue, workflow_update_issue and workflow_request_review tools)
+    expect(result.tools).toHaveLength(14);
 
     // Find workflow_status tool
     const statusTool = result.tools.find((t: Tool) => t.name === 'workflow_status');

--- a/mcp-workflow-server/src/index.ts
+++ b/mcp-workflow-server/src/index.ts
@@ -14,6 +14,7 @@ import { workflowReplyReview, workflowReplyReviewTool } from './tools/workflow-r
 import { workflowRequestReview, workflowRequestReviewTool } from './tools/workflow-request-review.js';
 import { workflowManageSubissues } from './tools/workflow-manage-subissues.js';
 import { workflowCreateIssue } from './tools/workflow-create-issue.js';
+import { workflowUpdateIssue } from './tools/workflow-update-issue.js';
 import { gitBranch } from './tools/git-branch.js';
 import { gitCommit } from './tools/git-commit.js';
 import { gitStash } from './tools/git-stash.js';
@@ -222,6 +223,36 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         },
       },
       {
+        name: 'workflow_update_issue',
+        description:
+          'Update GitHub issue project fields (status, type, priority) without needing GraphQL knowledge',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            issueNumber: {
+              type: 'number',
+              description: 'Issue number to update',
+            },
+            status: {
+              type: 'string',
+              enum: ['todo', 'in_progress', 'done'],
+              description: 'Update issue status (optional)',
+            },
+            type: {
+              type: 'string',
+              enum: ['epic', 'feature', 'bug', 'enhancement', 'documentation', 'question'],
+              description: 'Update issue type (optional)',
+            },
+            priority: {
+              type: 'string',
+              enum: ['low', 'medium', 'high', 'urgent'],
+              description: 'Update issue priority (optional)',
+            },
+          },
+          required: ['issueNumber'],
+        },
+      },
+      {
         name: 'git_branch',
         description:
           'Manage Git branches: checkout, create, pull, push, list branches, or start work on an issue',
@@ -359,6 +390,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         break;
       case 'workflow_create_issue':
         result = await workflowCreateIssue(request.params.arguments as { title: string; body: string; epicNumber?: number; type?: 'bug' | 'feature' | 'enhancement' | 'documentation' | 'question'; priority?: 'low' | 'medium' | 'high' | 'urgent'; labels?: string[]; assignees?: string[] });
+        break;
+      case 'workflow_update_issue':
+        result = await workflowUpdateIssue(request.params.arguments as { issueNumber: number; status?: 'todo' | 'in_progress' | 'done'; type?: 'epic' | 'feature' | 'bug' | 'enhancement' | 'documentation' | 'question'; priority?: 'low' | 'medium' | 'high' | 'urgent' });
         break;
       case 'git_branch':
         result = await gitBranch(request.params.arguments as { action: 'checkout' | 'create' | 'pull' | 'push' | 'list' | 'start-work'; branch?: string; issueNumber?: number; force?: boolean });

--- a/mcp-workflow-server/src/tools/__tests__/workflow-update-issue.test.ts
+++ b/mcp-workflow-server/src/tools/__tests__/workflow-update-issue.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { workflowUpdateIssue } from '../workflow-update-issue.js';
+import * as githubUtils from '../../utils/github.js';
+import * as authUtils from '../../utils/auth.js';
+import * as config from '../../config.js';
+import { Octokit } from '@octokit/rest';
+
+vi.mock('../../utils/github.js');
+vi.mock('../../utils/auth.js');
+vi.mock('../../config.js');
+vi.mock('@octokit/rest');
+
+describe('workflowUpdateIssue', () => {
+  const mockOctokit = {
+    graphql: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(Octokit).mockImplementation(() => mockOctokit as unknown as Octokit);
+    vi.mocked(authUtils.getGitHubToken).mockReturnValue('test-token');
+    vi.mocked(githubUtils.getRepoInfo).mockReturnValue({
+      owner: 'testowner',
+      repo: 'testrepo',
+    });
+    vi.mocked(config.getProjectConfig).mockReturnValue({
+      isComplete: true,
+      config: {
+        github: {
+          projectNumber: 1,
+          projectId: 'PVT_test',
+          statusFieldId: 'PVTSSF_status',
+          statusOptions: {
+            todo: 'PVTSSF_todo',
+            inProgress: 'PVTSSF_inprogress',
+            done: 'PVTSSF_done',
+          },
+        },
+      },
+    });
+  });
+
+  it('should update issue status successfully', async () => {
+    const mockProjectData = {
+      user: {
+        projectV2: {
+          id: 'PVT_test',
+          fields: {
+            nodes: [
+              {
+                id: 'PVTSSF_status',
+                name: 'Status',
+                options: [
+                  { id: 'PVTSSF_todo', name: 'Todo' },
+                  { id: 'PVTSSF_inprogress', name: 'In Progress' },
+                  { id: 'PVTSSF_done', name: 'Done' },
+                ],
+              },
+            ],
+          },
+          items: {
+            nodes: [
+              {
+                id: 'PVTI_item1',
+                content: { number: 123 },
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    mockOctokit.graphql
+      .mockResolvedValueOnce(mockProjectData) // For query
+      .mockResolvedValueOnce({ updateProjectV2ItemFieldValue: { projectV2Item: { id: 'PVTI_item1' } } }); // For mutation
+
+    const result = await workflowUpdateIssue({
+      issueNumber: 123,
+      status: 'in_progress',
+    });
+
+    expect(result.requestedData!).toEqual({
+      issueNumber: 123,
+      updatedFields: {
+        status: 'In Progress',
+      },
+      projectItemId: 'PVTI_item1',
+    });
+    expect(result.automaticActions).toContain('Updated status to "In Progress"');
+    expect(result.issuesFound).toHaveLength(0);
+  });
+
+  it('should update multiple fields successfully', async () => {
+    const mockProjectData = {
+      user: {
+        projectV2: {
+          id: 'PVT_test',
+          fields: {
+            nodes: [
+              {
+                id: 'PVTSSF_status',
+                name: 'Status',
+                options: [
+                  { id: 'PVTSSF_todo', name: 'Todo' },
+                  { id: 'PVTSSF_inprogress', name: 'In Progress' },
+                  { id: 'PVTSSF_done', name: 'Done' },
+                ],
+              },
+              {
+                id: 'PVTSSF_type',
+                name: 'Type',
+                options: [
+                  { id: 'PVTSSF_bug', name: 'Bug' },
+                  { id: 'PVTSSF_feature', name: 'Feature' },
+                ],
+              },
+              {
+                id: 'PVTSSF_priority',
+                name: 'Priority',
+                options: [
+                  { id: 'PVTSSF_low', name: 'Low' },
+                  { id: 'PVTSSF_high', name: 'High' },
+                ],
+              },
+            ],
+          },
+          items: {
+            nodes: [
+              {
+                id: 'PVTI_item1',
+                content: { number: 123 },
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    mockOctokit.graphql
+      .mockResolvedValueOnce(mockProjectData) // For query
+      .mockResolvedValueOnce({ updateProjectV2ItemFieldValue: { projectV2Item: { id: 'PVTI_item1' } } }) // For status
+      .mockResolvedValueOnce({ updateProjectV2ItemFieldValue: { projectV2Item: { id: 'PVTI_item1' } } }) // For type
+      .mockResolvedValueOnce({ updateProjectV2ItemFieldValue: { projectV2Item: { id: 'PVTI_item1' } } }); // For priority
+
+    const result = await workflowUpdateIssue({
+      issueNumber: 123,
+      status: 'done',
+      type: 'bug',
+      priority: 'high',
+    });
+
+    expect(result.requestedData!).toEqual({
+      issueNumber: 123,
+      updatedFields: {
+        status: 'Done',
+        type: 'Bug',
+        priority: 'High',
+      },
+      projectItemId: 'PVTI_item1',
+    });
+    expect(result.automaticActions).toContain('Updated status to "Done"');
+    expect(result.automaticActions).toContain('Updated type to "Bug"');
+    expect(result.automaticActions).toContain('Updated priority to "High"');
+    expect(result.issuesFound).toHaveLength(0);
+  });
+
+  it('should handle issue not found in project', async () => {
+    const mockProjectData = {
+      user: {
+        projectV2: {
+          id: 'PVT_test',
+          fields: { nodes: [] },
+          items: { nodes: [] },
+        },
+      },
+    };
+
+    mockOctokit.graphql.mockResolvedValueOnce(mockProjectData);
+
+    const result = await workflowUpdateIssue({
+      issueNumber: 999,
+      status: 'done',
+    });
+
+    expect(result.requestedData!.error).toBe('Issue #999 not found in project');
+    expect(result.issuesFound).toContain('Error: Issue #999 not found in project');
+  });
+
+  it('should handle invalid field value', async () => {
+    const mockProjectData = {
+      user: {
+        projectV2: {
+          id: 'PVT_test',
+          fields: {
+            nodes: [
+              {
+                id: 'PVTSSF_status',
+                name: 'Status',
+                options: [
+                  { id: 'PVTSSF_todo', name: 'Todo' },
+                  { id: 'PVTSSF_done', name: 'Done' },
+                ],
+              },
+            ],
+          },
+          items: {
+            nodes: [
+              {
+                id: 'PVTI_item1',
+                content: { number: 123 },
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    mockOctokit.graphql.mockResolvedValueOnce(mockProjectData);
+
+    const result = await workflowUpdateIssue({
+      issueNumber: 123,
+      status: 'in_progress', // This value doesn't exist in options
+    });
+
+    expect(result.issuesFound).toContain('Invalid status value: in_progress');
+    expect(result.requestedData!.updatedFields).toEqual({});
+  });
+
+  it('should handle missing project configuration', async () => {
+    vi.mocked(config.getProjectConfig).mockReturnValue({
+      isComplete: false,
+      config: {
+        github: {},
+      },
+    });
+
+    const result = await workflowUpdateIssue({
+      issueNumber: 123,
+      status: 'done',
+    });
+
+    expect(result.requestedData!.error).toBe('Project configuration not found. Run workflow_configure first.');
+    expect(result.issuesFound).toContain('Error: Project configuration not found. Run workflow_configure first.');
+  });
+
+  it('should handle no fields to update', async () => {
+    const mockProjectData = {
+      user: {
+        projectV2: {
+          id: 'PVT_test',
+          fields: { nodes: [] },
+          items: {
+            nodes: [
+              {
+                id: 'PVTI_item1',
+                content: { number: 123 },
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    mockOctokit.graphql.mockResolvedValueOnce(mockProjectData);
+
+    const result = await workflowUpdateIssue({
+      issueNumber: 123,
+    });
+
+    expect(result.suggestedActions).toContain('No fields were updated. Specify status, type, or priority to update.');
+    expect(result.requestedData!.updatedFields).toEqual({});
+  });
+
+  it('should handle field not found in project', async () => {
+    const mockProjectData = {
+      user: {
+        projectV2: {
+          id: 'PVT_test',
+          fields: {
+            nodes: [], // No fields defined
+          },
+          items: {
+            nodes: [
+              {
+                id: 'PVTI_item1',
+                content: { number: 123 },
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    mockOctokit.graphql.mockResolvedValueOnce(mockProjectData);
+
+    const result = await workflowUpdateIssue({
+      issueNumber: 123,
+      status: 'done',
+      type: 'bug',
+      priority: 'high',
+    });
+
+    expect(result.issuesFound).toContain('Status field not found in project');
+    expect(result.issuesFound).toContain('Type field not found in project');
+    expect(result.issuesFound).toContain('Priority field not found in project');
+    expect(result.requestedData!.updatedFields).toEqual({});
+  });
+});

--- a/mcp-workflow-server/src/tools/workflow-update-issue.ts
+++ b/mcp-workflow-server/src/tools/workflow-update-issue.ts
@@ -138,7 +138,7 @@ export async function workflowUpdateIssue(
         issuesFound.push('Status field not found in project');
       } else {
         const statusOption = statusField.options?.find(
-          (opt) => opt.name.toLowerCase() === status.replace('_', ' ')
+          (opt) => opt.name.toLowerCase() === status.replace(/_/g, ' ')
         );
         
         if (!statusOption) {

--- a/mcp-workflow-server/src/tools/workflow-update-issue.ts
+++ b/mcp-workflow-server/src/tools/workflow-update-issue.ts
@@ -1,0 +1,269 @@
+import { WorkflowResponse, PRStatus } from '../types.js';
+import { getRepoInfo } from '../utils/github.js';
+import { Octokit } from '@octokit/rest';
+import { getGitHubToken } from '../utils/auth.js';
+import { getProjectConfig } from '../config.js';
+
+interface UpdateIssueFieldsParams {
+  issueNumber: number;
+  status?: 'todo' | 'in_progress' | 'done';
+  type?: 'epic' | 'feature' | 'bug' | 'enhancement' | 'documentation' | 'question';
+  priority?: 'low' | 'medium' | 'high' | 'urgent';
+}
+
+interface ProjectFieldOption {
+  id: string;
+  name: string;
+}
+
+interface ProjectField {
+  id: string;
+  name: string;
+  options?: ProjectFieldOption[];
+}
+
+interface ProjectItem {
+  id: string;
+  content?: {
+    number?: number;
+  };
+}
+
+interface ProjectQueryResult {
+  user?: {
+    projectV2?: {
+      id: string;
+      fields?: {
+        nodes?: ProjectField[];
+      };
+      items?: {
+        nodes?: ProjectItem[];
+      };
+    };
+  };
+}
+
+
+export async function workflowUpdateIssue(
+  params: UpdateIssueFieldsParams
+): Promise<WorkflowResponse> {
+  const automaticActions: string[] = [];
+  const issuesFound: string[] = [];
+  const suggestedActions: string[] = [];
+  const allPRStatus: PRStatus[] = [];
+
+  try {
+    const { issueNumber, status, type, priority } = params;
+    
+    if (!issueNumber) {
+      throw new Error('Issue number is required');
+    }
+
+    // Get configuration
+    const configResult = getProjectConfig();
+    if (!configResult.isComplete || !configResult.config.github.projectId || !configResult.config.github.projectNumber) {
+      throw new Error('Project configuration not found. Run workflow_configure first.');
+    }
+    const config = configResult.config.github;
+
+    const token = getGitHubToken();
+    const octokit = new Octokit({ auth: token });
+    const { owner } = getRepoInfo();
+
+    automaticActions.push(`Processing update for issue #${issueNumber}`);
+
+    // First, get the project item ID for this issue
+    const projectQuery = `
+      query($owner: String!, $projectNumber: Int!) {
+        user(login: $owner) {
+          projectV2(number: $projectNumber) {
+            id
+            fields(first: 20) {
+              nodes {
+                ... on ProjectV2Field {
+                  id
+                  name
+                }
+                ... on ProjectV2SingleSelectField {
+                  id
+                  name
+                  options {
+                    id
+                    name
+                  }
+                }
+              }
+            }
+            items(first: 100) {
+              nodes {
+                id
+                content {
+                  ... on Issue {
+                    number
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    `;
+
+    const projectResult = await octokit.graphql<ProjectQueryResult>(projectQuery, {
+      owner,
+      projectNumber: config.projectNumber!,
+    });
+
+    // Find the project item for this issue
+    const projectItems = projectResult.user?.projectV2?.items?.nodes || [];
+    const projectItem = projectItems.find(
+      (item) => item.content?.number === issueNumber
+    );
+
+    if (!projectItem) {
+      throw new Error(`Issue #${issueNumber} not found in project`);
+    }
+
+    const projectItemId = projectItem.id;
+    automaticActions.push(`Found project item ID: ${projectItemId}`);
+
+    // Get field information
+    const fields = projectResult.user?.projectV2?.fields?.nodes || [];
+    const updatedFields: Record<string, string> = {};
+
+    // Update status if provided
+    if (status) {
+      const statusField = fields.find((f) => f.name === 'Status');
+      if (!statusField) {
+        issuesFound.push('Status field not found in project');
+      } else {
+        const statusOption = statusField.options?.find(
+          (opt) => opt.name.toLowerCase() === status.replace('_', ' ')
+        );
+        
+        if (!statusOption) {
+          issuesFound.push(`Invalid status value: ${status}`);
+        } else {
+          await updateProjectField(
+            octokit,
+            config.projectId!,
+            projectItemId,
+            statusField.id,
+            { singleSelectOptionId: statusOption.id }
+          );
+          updatedFields.status = statusOption.name;
+          automaticActions.push(`Updated status to "${statusOption.name}"`);
+        }
+      }
+    }
+
+    // Update type if provided
+    if (type) {
+      const typeField = fields.find((f) => f.name === 'Type');
+      if (!typeField) {
+        issuesFound.push('Type field not found in project');
+      } else {
+        const typeOption = typeField.options?.find(
+          (opt) => opt.name.toLowerCase() === type.toLowerCase()
+        );
+        
+        if (!typeOption) {
+          issuesFound.push(`Invalid type value: ${type}`);
+        } else {
+          await updateProjectField(
+            octokit,
+            config.projectId!,
+            projectItemId,
+            typeField.id,
+            { singleSelectOptionId: typeOption.id }
+          );
+          updatedFields.type = typeOption.name;
+          automaticActions.push(`Updated type to "${typeOption.name}"`);
+        }
+      }
+    }
+
+    // Update priority if provided
+    if (priority) {
+      const priorityField = fields.find((f) => f.name === 'Priority');
+      if (!priorityField) {
+        issuesFound.push('Priority field not found in project');
+      } else {
+        const priorityOption = priorityField.options?.find(
+          (opt) => opt.name.toLowerCase() === priority.toLowerCase()
+        );
+        
+        if (!priorityOption) {
+          issuesFound.push(`Invalid priority value: ${priority}`);
+        } else {
+          await updateProjectField(
+            octokit,
+            config.projectId!,
+            projectItemId,
+            priorityField.id,
+            { singleSelectOptionId: priorityOption.id }
+          );
+          updatedFields.priority = priorityOption.name;
+          automaticActions.push(`Updated priority to "${priorityOption.name}"`);
+        }
+      }
+    }
+
+    if (Object.keys(updatedFields).length === 0) {
+      suggestedActions.push('No fields were updated. Specify status, type, or priority to update.');
+    }
+
+    return {
+      requestedData: {
+        issueNumber,
+        updatedFields,
+        projectItemId,
+      },
+      automaticActions,
+      issuesFound,
+      suggestedActions,
+      allPRStatus,
+    };
+  } catch (error) {
+    issuesFound.push(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    return {
+      requestedData: {
+        error: error instanceof Error ? error.message : String(error),
+      },
+      automaticActions,
+      issuesFound,
+      suggestedActions,
+      allPRStatus,
+    };
+  }
+}
+
+async function updateProjectField(
+  octokit: Octokit,
+  projectId: string,
+  itemId: string,
+  fieldId: string,
+  value: { singleSelectOptionId: string }
+): Promise<void> {
+  const mutation = `
+    mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: ProjectV2FieldValue!) {
+      updateProjectV2ItemFieldValue(input: {
+        projectId: $projectId,
+        itemId: $itemId,
+        fieldId: $fieldId,
+        value: $value
+      }) {
+        projectV2Item {
+          id
+        }
+      }
+    }
+  `;
+
+  await octokit.graphql(mutation, {
+    projectId,
+    itemId,
+    fieldId,
+    value,
+  });
+}


### PR DESCRIPTION
## Summary

This PR implements MCP Tool: Update GitHub issue project fields.

## Related Issue

Closes #80

## Changes

- Updated 2 files in `mcp-workflow-server/`
- Updated 2 files in `.../`

## Test Plan

Based on acceptance criteria:
- [ ] Tool accepts issue number and field updates
- [ ] Maps human-readable values to internal IDs
- [ ] Supports partial updates (only specified fields)
- [ ] Validates field values before updating
- [ ] Returns updated issue state

🤖 Generated with [MCP Workflow Server](https://github.com/jwilger/event_modeler)


<!-- DIAGRAM_START -->
## 📊 Event Model Diagram Preview

Generated from `tests/fixtures/acceptance/example.eventmodel`:

![Event Model Diagram](https://gist.githubusercontent.com/jwilger/dc789014cafae10bc5ab46c38ce9d9c3/raw/example.svg)

> **View options:**
> - Click image to view full size
> - [Open in new tab](https://gist.githubusercontent.com/jwilger/dc789014cafae10bc5ab46c38ce9d9c3/raw/example.svg)
> - [View gist](https://gist.github.com/dc789014cafae10bc5ab46c38ce9d9c3)

### Current Progress: Step 2 - Swimlanes
✅ Workflow title
✅ Horizontal swimlanes with labels

---
🤖 *Generated by CI build #339*
<!-- DIAGRAM_END -->